### PR TITLE
Remove layoutMonitor from ToInfiniteElement

### DIFF
--- a/src/Toplo-Widget-List/ToInfiniteElement.class.st
+++ b/src/Toplo-Widget-List/ToInfiniteElement.class.st
@@ -4,7 +4,6 @@ Class {
 	#traits : 'TBlLayoutResizable',
 	#classTraits : 'TBlLayoutResizable classTrait',
 	#instVars : [
-		'layoutMonitor',
 		'nodeHolderFactory',
 		'listElement'
 	],
@@ -52,12 +51,6 @@ ToInfiniteElement >> disableScrolledEvent [
 	self eventDispatcher disableScrolledEvent 
 ]
 
-{ #category : #layout }
-ToInfiniteElement >> dispatchLayout [
-
-	self layoutCritical: [ super dispatchLayout ]
-]
-
 { #category : #'scrolled event' }
 ToInfiniteElement >> enableScrolledEvent [
 
@@ -74,14 +67,13 @@ ToInfiniteElement >> infinite [
 ToInfiniteElement >> initialize [
 
 	super initialize.
-	layoutMonitor := Monitor new.
 	self matchParent
 ]
 
 { #category : #layout }
 ToInfiniteElement >> layoutCritical: aBlock [
 			
-	layoutMonitor critical: aBlock
+	aBlock value
 ]
 
 { #category : #accessing }
@@ -124,18 +116,17 @@ ToInfiniteElement >> nodeContainingGlobalPosition: aPoint [
 ToInfiniteElement >> nodeGroupsSatisfying: aBlock [
 	" return an array of collection. Each collection contains a list of adjacent selected nodes "
 
-	self layoutCritical: [
-		^ Array streamContents: [ :stream |
-			  | g |
-			  g := OrderedCollection new.
-			  self childrenDo: [ :node |
-				  (aBlock value: node)
-					  ifTrue: [ g add: node ]
-					  ifFalse: [
-						  g ifNotEmpty: [
-							  stream nextPut: g.
-							  g := OrderedCollection new ] ] ].
-			  g ifNotEmpty: [ stream nextPut: g ] ] ]
+	^ Array streamContents: [ :stream |
+		  | g |
+		  g := OrderedCollection new.
+		  self childrenDo: [ :node |
+			  (aBlock value: node)
+				  ifTrue: [ g add: node ]
+				  ifFalse: [
+					  g ifNotEmpty: [
+						  stream nextPut: g.
+						  g := OrderedCollection new ] ] ].
+		  g ifNotEmpty: [ stream nextPut: g ] ]
 ]
 
 { #category : #'accessing - nodes' }


### PR DESCRIPTION
It shouldn't be needed as it is done from the layout phase in the main host loop process, but I may be wrong.