### PR TITLE
Add ‘Toplo-Demo’ to #registerPackages: on BaselineOfToplo

### DIFF
--- a/src/BaselineOfToplo/BaselineOfToplo.class.st
+++ b/src/BaselineOfToplo/BaselineOfToplo.class.st
@@ -116,6 +116,12 @@ BaselineOfToplo >> registerPackages: spec [
 			#( #Toplo #'Toplo-Widget-Album' #'Toplo-Widget-Button'
 			   #'Toplo-Widget-Image' #'Toplo-Theme') ].
 
+	spec package: #'Toplo-Demo' with: [
+		spec requires:
+			#( #Toplo #'Toplo-Widget-Album'
+				#'Toplo-Widget-Button' #'Toplo-Widget-Image'
+				#'Toplo-Widget-List' #'Toplo-Widget-Pane' ) ].
+
 	spec package: #'Toplo-Examples' with: [
 		spec requires:
 			#( #Toplo #'Toplo-Widget-Album' 


### PR DESCRIPTION
This pull request adds the package ‘Toplo-Demo’ to #registerPackages: on BaselineOfToplo. The required packages are listed as given by the Dependency Analyzer.