### PR TITLE
Move methods in ToploDemoPresenter’s protocol ‘demos’ to the class side

### DIFF
--- a/src/Toplo-Demo/ToploDemoPresenter.class.st
+++ b/src/Toplo-Demo/ToploDemoPresenter.class.st
@@ -4,28 +4,8 @@ Class {
 	#category : #'Toplo-Demo'
 }
 
-{ #category : #running }
-ToploDemoPresenter class >> menuCommandOn: aBuilder [
-
-	<worldMenu>
-
-	(aBuilder item: #'Open Toplo Demo')
-		action: [ self open ];
-		parent: #Help;
-		iconName: #group;
-		withSeparatorAfter
-]
-
-{ #category : #running }
-ToploDemoPresenter class >> open [
-
-	<script>
-
-	super open
-]
-
 { #category : #demos }
-ToploDemoPresenter >> demo1 [
+ToploDemoPresenter class >> demo1 [
 
 	<demo>
 
@@ -36,7 +16,7 @@ ToploDemoPresenter >> demo1 [
 ]
 
 { #category : #demos }
-ToploDemoPresenter >> demo2 [
+ToploDemoPresenter class >> demo2 [
 
 	<demo>
 	| list colorAssociations |
@@ -71,7 +51,7 @@ ToploDemoPresenter >> demo2 [
 ]
 
 { #category : #demos }
-ToploDemoPresenter >> demo3 [
+ToploDemoPresenter class >> demo3 [
 
 	<demo>
 	| containerElement radioButtonLightTheme radioButtonDarkTheme checkableGroup |
@@ -99,6 +79,26 @@ ToploDemoPresenter >> demo3 [
 								  ifFalse: [ ToRawDarkTheme new ]) ]).
 	containerElement addChildren: checkableGroup buttons.
 	^ containerElement
+]
+
+{ #category : #running }
+ToploDemoPresenter class >> menuCommandOn: aBuilder [
+
+	<worldMenu>
+
+	(aBuilder item: #'Open Toplo Demo')
+		action: [ self open ];
+		parent: #Help;
+		iconName: #group;
+		withSeparatorAfter
+]
+
+{ #category : #running }
+ToploDemoPresenter class >> open [
+
+	<script>
+
+	super open
 ]
 
 { #category : #private }


### PR DESCRIPTION
This pull request moves the methods in ToploDemoPresenter’s protocol ‘demos’ to the class side. This depends on [Bloc pull request #593](https://github.com/pharo-graphics/Bloc/pull/593). The addition of [Bloc pull request #594](https://github.com/pharo-graphics/Bloc/pull/594) will allow the demos to be executed in a browser.