### PR TITLE
ToSandBox: Use #sorted instead of #sort 

### DIFF
--- a/src/Toplo-Examples/ToSandBox.class.st
+++ b/src/Toplo-Examples/ToSandBox.class.st
@@ -419,7 +419,7 @@ ToSandBox class >> buildSelectListElementIn: aSelectElement withIconProvider: an
 			             s := ('_' , style prefix , '_loaded') asSymbol.
 			             (icProvider respondsTo: s) ifTrue: [
 				             | iconNames |
-				             iconNames := (icProvider perform: s) sort.
+				             iconNames := (icProvider perform: s) sorted.
 				             iconNames do: [ :n |
 					             stream nextPut: (ToIconDescExampleObject new
 							              name: n;


### PR DESCRIPTION
because we don't want to update the collection in place. 

Fixes #263