### PR TITLE
Pass on CI: make more similar to Bloc's CI

### DIFF
--- a/.ci.ston
+++ b/.ci.ston
@@ -3,8 +3,8 @@ SmalltalkCISpec {
     SCIMetacelloLoadSpec {
       #baseline : 'Toplo',
       #directory : 'src',
-      #onConflict : #useIncoming,   
-      #platforms : [ #pharo ]
+      #platforms : [ #pharo ],
+      #registerInIceberg : true
     }
   ]
 }

--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -1,29 +1,33 @@
-name: 'Tests'
+name: Tests
 
 on:
   push:
-    branches:
-      - 'dev'
-      - 'master'
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"   # Run every Monday at 08:00
 
 jobs:
-  build:
+  test:
     strategy:
+      # Default value means that a failure in one OS cancels all 
+      fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest, windows-latest ]
-        smalltalk: [ Pharo64-12, Pharo64-13 ]
+        smalltalk: [ Pharo64-12, Pharo64-13, Pharo64-14 ]
+        os: [ windows-latest ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: hpi-swa/setup-smalltalkCI@v1
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Setup smalltalkCI
+        uses: hpi-swa/setup-smalltalkCI@v1
         with:
           smalltalk-image: ${{ matrix.smalltalk }}
       - name: Load in New Image and Run Tests
-        run: smalltalkci -s ${{ matrix.smalltalk }} ${{ matrix.ston }}
+        run: smalltalkci -s ${{ matrix.smalltalk }} .ci.ston
         shell: bash
-        timeout-minutes: 30
-        env: 
+        timeout-minutes: 10
+        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.properties
+++ b/.properties
@@ -1,3 +1,0 @@
-{
-	#format : #tonel
-}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![License](https://img.shields.io/github/license/pharo-graphics/Toplo.svg)](./LICENSE)
 [![Tests](https://github.com/pharo-graphics/Toplo/actions/workflows/Tests.yml/badge.svg)](https://github.com/pharo-graphics/Toplo/actions/workflows/Tests.yml)
 
-<img width="1298" alt="Capture d’écran 2025-04-23 à 22 47 08" src="https://github.com/user-attachments/assets/d442368b-88f6-42c4-816f-483f6ce246be" />
-<img width="1274" alt="Capture d’écran 2025-04-23 à 22 46 11" src="https://github.com/user-attachments/assets/a3a1e4da-4a2c-42c8-a4f7-b705ec1ac941" />
+<img width="1298" alt="Screenshot #1" src="https://github.com/user-attachments/assets/d442368b-88f6-42c4-816f-483f6ce246be" />
+<img width="1274" alt="Screenshot #2" src="https://github.com/user-attachments/assets/a3a1e4da-4a2c-42c8-a4f7-b705ec1ac941" />
 
 # Toplo
 
@@ -21,6 +21,7 @@ The project can be loaded as usual via Metacello, using the `BaselineOfToplo` sp
 
 
 ## Branches & Contributions
+
 We describe our contribution workflow & branch name convention in [this wiki page](../../wiki/Branches-and-versions).
 
 


### PR DESCRIPTION
- Rename the ston as .ci.ston
- Do not fail-fast
- Run on Pharo 12, 13 and 14
- But run only on one OS (it should be enough, and more OSs would be too much noise)
- Delete uneeded .properties file (the used properties is in /src directory)
- Also do a small clean up on README
- Remove an invalid reference to non-existing variable: ${{ matrix.ston }}