### PR TITLE
Handle BlDoubleClickEvent in ToCheckableEventHandler

### DIFF
--- a/src/Toplo-Widget-Button-Tests/ToCheckboxTest.class.st
+++ b/src/Toplo-Widget-Button-Tests/ToCheckboxTest.class.st
@@ -124,7 +124,7 @@ ToCheckboxTest >> testStartUnchecked [
 { #category : #tests }
 ToCheckboxTest >> testSwitchToNextCheckStateOnClick [
 
-	| cb  |
+	| cb |
 	cb := ToCheckbox new.
 	space root addChild: cb.
 	self deny: cb checked.
@@ -132,11 +132,18 @@ ToCheckboxTest >> testSwitchToNextCheckStateOnClick [
 	self assert: cb checked.
 	cb switchToNextCheckStateOnClick: false.
 	BlSpace simulateClickOn: cb.
+	self assert: cb checked
+]
+
+{ #category : #tests }
+ToCheckboxTest >> testSwitchToNextCheckStateOnDoubleClick [
+
+	| cb |
+	cb := ToCheckbox new.
+	space root addChild: cb.
+	self deny: cb checked.
+	BlSpace simulateClickOn: cb.
 	self assert: cb checked.
-
-	
-	
-
-	
-
+	BlSpace simulateClickOn: cb.
+	self deny: cb checked
 ]

--- a/src/Toplo-Widget-Button/ToCheckableEventHandler.class.st
+++ b/src/Toplo-Widget-Button/ToCheckableEventHandler.class.st
@@ -23,12 +23,19 @@ ToCheckableEventHandler >> clickEvent: anEvent [
 
 ]
 
+{ #category : #'event handling' }
+ToCheckableEventHandler >> doubleClickEvent: anEvent [
+
+	self clickEvent: anEvent
+]
+
 { #category : #'api - accessing' }
 ToCheckableEventHandler >> eventsToHandle [
 
 	^ {
 		  ToCheckableChangedEvent.
-		  BlClickEvent }
+		  BlClickEvent.
+		  BlDoubleClickEvent }
 ]
 
 { #category : #'event handling' }


### PR DESCRIPTION
… to support rapid toggling

The `testElementWithTooltipAndPopupWindowManager` makes CI red but it was already failing before my commit.

Fixes #397 