### PR TITLE
Add #isSettledIn: support on space phases + adopt Bloc #deferAndSettle: in tests

### DIFF
--- a/src/Toplo-Demo/ToDemoPresenter.class.st
+++ b/src/Toplo-Demo/ToDemoPresenter.class.st
@@ -59,14 +59,15 @@ ToDemoPresenter class >> demo3 [
 	{
 		ToRawTheme.
 		ToRawDarkTheme } do: [ :themeClass |
-			containerElement addChild: (ToRadioButton new
+			containerElement addChild:
+				(ToRadioButton new
 					 labelText: themeClass label;
 					 in: [ :rad | rad userData at: #themeClass put: themeClass ];
 					 yourself) ].
 				
 	containerElement groupCheckAction: [ :evt |
-			containerElement space toTheme:
-				(evt checkedList anyOne userData at: #themeClass) new ].
+		containerElement space toTheme:
+			(evt checkedList anyOne userData at: #themeClass) new ].
 
 	containerElement children second checked: true.
 
@@ -94,8 +95,8 @@ ToDemoPresenter class >> open [
 { #category : #private }
 ToDemoPresenter >> drawOnCanvas: anElement [
 
-	self canva space toTheme: ToRawTheme new.
-	super drawOnCanvas: anElement.
+	self canvas space toTheme: ToRawTheme new.
+	super drawOnCanvas: anElement
 ]
 
 { #category : #accessing }

--- a/src/Toplo-Demo/ToSkinDemoStyleSheetTest.class.st
+++ b/src/Toplo-Demo/ToSkinDemoStyleSheetTest.class.st
@@ -60,10 +60,10 @@ ToSkinDemoStyleSheetTest >> testRuleBackgroundDependsOnParentOrChildren [
 		              position: 150 @ 50.
 	childElem := ToElement new.
 	parentElem addChild: childElem.
-	space toTheme: theme.
-	space root addChild: elem.
-	space root addChild: parentElem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: elem.
+		space root addChild: parentElem ].
 	self assert: elem background paint color equals: Color red.
 	self assert: parentElem background paint color equals: Color blue.
 	self assert: childElem background paint color equals: Color green
@@ -112,9 +112,9 @@ ToSkinDemoStyleSheetTest >> testRuleBackgroundDependsOnSibling [
 			sibling1.
 			sibling2 }.
 
-	space toTheme: theme.
-	space root addChild: container.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: container ].
 	self assert: sibling1 background paint color equals: Color blue.
 	self assert: sibling2 background paint color equals: Color green.
 	self assert: container background paint color equals: Color red
@@ -168,27 +168,18 @@ ToSkinDemoStyleSheetTest >> testRuleBackgroundDependsOnSizeWithActionBlock [
 		              extent: 100 asPoint;
 		              position: 150 asPoint.
 
-	space root addChild: elem.
-	space root addChild: verticalElem.
-	space root addChild: horizontalElem.
-	space root addChild: biggerElem.
+	space deferAndSettle: [
+		space root addChild: elem.
+		space root addChild: verticalElem.
+		space root addChild: horizontalElem.
+		space root addChild: biggerElem ].
 
-	assertsTested := false.
-	space root whenLayoutedDoOnce: [
-			assertsTested := true.
-			space toTheme: theme.
-			self waitTestingSpaces.
-			self assert: elem background paint color equals: Color green.
-			self
-				assert: verticalElem background paint color
-				equals: Color yellow.
-			self
-				assert: horizontalElem background paint color
-				equals: Color blue.
-			self assert: biggerElem background paint color equals: Color red ].
+	space deferAndSettle: [ space toTheme: theme ].
 
-	space root forceLayout.
-	self assert: assertsTested
+	self assert: elem background paint color equals: Color green.
+	self assert: verticalElem background paint color equals: Color yellow.
+	self assert: horizontalElem background paint color equals: Color blue.
+	self assert: biggerElem background paint color equals: Color red
 ]
 
 { #category : #tests }

--- a/src/Toplo-Examples/ToExWorkspace.class.st
+++ b/src/Toplo-Examples/ToExWorkspace.class.st
@@ -15,7 +15,7 @@ Class {
 ToExWorkspace class >> open [
 
 	<script>
-	self openInHost: BlOSWindowSDL2Host new
+	self openInHost: BlOSWindowSDL2Host default
 ]
 
 { #category : #'instance creation' }
@@ -33,14 +33,14 @@ ToExWorkspace class >> openInHost: aBlOSWindowHost [
 ToExWorkspace class >> openInMorphic [
 
 	<script>
-	self openInHost: BlMorphicWindowHost new
+	self openInHost: BlMorphicWindowHost default
 ]
 
 { #category : #'instance creation' }
 ToExWorkspace class >> openInSDL [
 
 	<script>
-	self openInHost: BlOSWindowSDL2Host new
+	self openInHost: BlOSWindowSDL2Host default
 ]
 
 { #category : #binding }

--- a/src/Toplo-Examples/ToExperiments.class.st
+++ b/src/Toplo-Examples/ToExperiments.class.st
@@ -697,8 +697,7 @@ ToExperiments class >> example_PasteUpWithPlaceHolder [
 			event consume ].
 	blue addEventHandlerOn: BlDragEvent do: [ :event |
 			event consume.
-			blue position: event position - pblue.
-			blue forceLayout ].
+			blue position: event position - pblue ].
 	blue addEventHandlerOn: BlDragEndEvent do: [ :event | event consume ].
 
 	blue
@@ -1621,7 +1620,6 @@ ToExperiments class >> example_twoChildrenMatchParentInFitContent [
 			c vertical matchParent ].
 	parent addChild: child.
 	parent addChild: child2.
-	parent forceLayout.
 	^ parent openInSpace 
 ]
 

--- a/src/Toplo-Examples/ToExperimentsMockTest.class.st
+++ b/src/Toplo-Examples/ToExperimentsMockTest.class.st
@@ -7,15 +7,7 @@ Class {
 { #category : #tests }
 ToExperimentsMockTest >> closeWindows [
 
-	{
-		BlOSWindowSDL2Host.
-		BlMorphicWindowHost } do: [ :host |
-			host universe closeSpaces.
-			host
-				stop;
-				start ].
-	BlSpace allInstances do: [ :each | each close ].
-	BlParallelUniverse all do: [ :each | each closeSpaces ]
+	Toplo closeSpaces
 ]
 
 { #category : #tests }

--- a/src/Toplo-Examples/ToFiniteListElementStresserWithActionMethods.class.st
+++ b/src/Toplo-Examples/ToFiniteListElementStresserWithActionMethods.class.st
@@ -171,7 +171,7 @@ ToFiniteListElementStresserWithActionMethods >> processBlock [
 		  self maxRound timesRepeat: [
 				  round := round + 1.
 				  self selectActionsToRun shuffled do: [ :act |
-					  list inUIProcessDo: [ self perform: act with: list ] ] ].
+					  list deferOrValue: [ self perform: act with: list ] ] ].
 		  endTime := DateAndTime now.
 		  (endTime - startTime) asDuration traceCr ]
 ]

--- a/src/Toplo-Examples/ToListElementStresser.class.st
+++ b/src/Toplo-Examples/ToListElementStresser.class.st
@@ -31,7 +31,7 @@ ToListElementStresser class >> run [
 ToListElementStresser class >> runInSDL [
 
 	<script>
-	self new runInHost: BlOSWindowSDL2Host new
+	self new runInHost: BlOSWindowSDL2Host default
 ]
 
 { #category : #actions }

--- a/src/Toplo-Examples/ToListElementStresserWithAdditionalSelecters.class.st
+++ b/src/Toplo-Examples/ToListElementStresserWithAdditionalSelecters.class.st
@@ -22,7 +22,7 @@ ToListElementStresserWithAdditionalSelecters class >> run [
 ToListElementStresserWithAdditionalSelecters class >> runInSDL [
 
 	<script>
-	self new runInHost: BlOSWindowSDL2Host new
+	self new runInHost: BlOSWindowSDL2Host default
 ]
 
 { #category : #actions }

--- a/src/Toplo-Examples/ToSandBox.class.st
+++ b/src/Toplo-Examples/ToSandBox.class.st
@@ -3396,9 +3396,10 @@ ToSandBox class >> example_ListWithAllClassesAndTraitsSorted [
 	| l vscrollBar space |
 	l := ToListElement new nodeBuilder: [ :node :dataItem :holder |
 			node ensureCanManageToploSkin.
-		     node addChild: (ToClassNameViewExamplePart new
-				      class: dataItem position: holder position;
-				      yourself) ].
+			node addChild:
+				(ToClassNameViewExamplePart new
+					class: dataItem position: holder position;
+					yourself) ].
 	l withRowNumbers.
 	l dataAccessor addAll:
 		(Smalltalk allClassesAndTraits sorted: [ :a :b | a name < b name ]).
@@ -3692,7 +3693,6 @@ ToSandBox class >> example_Menu2 [
 
 { #category : #menu }
 ToSandBox class >> example_Menu3 [
-	<demo>
 	
 	| container |
 	container := ToElement new matchParent.
@@ -6137,7 +6137,6 @@ ToSandBox class >> example_ToggleButtonInListElement [
 
 	space := BlSpace new.
 	space root addChild: moveListElement.
-	space pulse.
 	space resizable: true.
 	space show
 ]
@@ -7141,7 +7140,7 @@ ToSandBox class >> example_hugePane [
 	space root addChild: pane.
 	space show.
 
-	space root inUIProcessDo: [
+	space root deferOrValue: [
 			1 to: 100 do: [ :i | 
 					| label button |
 					label := 'Button ' , i asString.

--- a/src/Toplo-Examples/ToSandBoxMockTest.class.st
+++ b/src/Toplo-Examples/ToSandBoxMockTest.class.st
@@ -7,15 +7,7 @@ Class {
 { #category : #tests }
 ToSandBoxMockTest >> closeWindows [
 
-	{
-		BlOSWindowSDL2Host.
-		BlMorphicWindowHost } do: [ :host |
-			host universe closeSpaces.
-			host
-				stop;
-				start ].
-	BlSpace allInstances do: [ :each | each close ].
-	BlParallelUniverse all do: [ :each | each closeSpaces ]
+	Toplo closeSpaces
 ]
 
 { #category : #tests }

--- a/src/Toplo-Examples/ToSimpleFiniteListElementStresser.class.st
+++ b/src/Toplo-Examples/ToSimpleFiniteListElementStresser.class.st
@@ -30,61 +30,61 @@ ToSimpleFiniteListElementStresser >> processBlock [
 				  round := round + 1.
 				  self storeRunnedAction:
 					  'list dataAccessor addAll: (1 to: size).'.
-				  list inUIProcessDo: [ list dataAccessor addAll: (1 to: size) ].
+				  list deferOrValue: [ list dataAccessor addAll: (1 to: size) ].
 
 				  self storeRunnedAction:
 					  'list dataAccessor add: 1 afterIndex: 36.'.
-				  list inUIProcessDo: [ list dataAccessor add: 1 afterIndex: 36 ].
+				  list deferOrValue: [ list dataAccessor add: 1 afterIndex: 36 ].
 
 				  self storeRunnedAction:
 					  'list selecter selectIndexes: #( 65 93 25 85 71 4 57 59 38 26 7 63 58 76 58 62 33 6 51 67 25 ).'.
-				  list inUIProcessDo: [
+				  list deferOrValue: [
 						  list selecter selectIndexes:
 							  #( 65 93 25 85 71 4 57 59 38 26 7 63 58 76 58 62 33 6 51 67
 							     25 ) ].
 
 				  self storeRunnedAction: 'list dataAccessor at: 8 put: 2.'.
-				  list inUIProcessDo: [ list dataAccessor at: 8 put: 2 ].
+				  list deferOrValue: [ list dataAccessor at: 8 put: 2 ].
 
 				  self storeRunnedAction: 'list selecter selectIndex: 69 to: 54.'.
-				  list inUIProcessDo: [ list selecter selectIndex: 69 to: 54 ].
+				  list deferOrValue: [ list selecter selectIndex: 69 to: 54 ].
 				
 				  self storeRunnedAction: 'list selecter selectAll.'.
-				  list inUIProcessDo: [ list selecter selectAll ].
+				  list deferOrValue: [ list selecter selectAll ].
 
 				  self storeRunnedAction: 'list dataAccessor removeAll.'.
-				  list inUIProcessDo: [ list dataAccessor removeAll ].
+				  list deferOrValue: [ list dataAccessor removeAll ].
 
 
 				  self storeRunnedAction: 'list selecter deselectAll.'.
-				  list inUIProcessDo: [ list selecter deselectAll ].
+				  list deferOrValue: [ list selecter deselectAll ].
 
 				  self storeRunnedAction: 'list dataAccessor removeAll.'.
-				  list inUIProcessDo: [ list dataAccessor removeAll ].
+				  list deferOrValue: [ list dataAccessor removeAll ].
 
 				  self storeRunnedAction:
 					  'list dataAccessor add: 3 afterIndex: 0.'.
-				  list inUIProcessDo: [ list dataAccessor add: 3 afterIndex: 0 ].
+				  list deferOrValue: [ list dataAccessor add: 3 afterIndex: 0 ].
 
 				  self storeRunnedAction: 'list selecter deselectIndexes: #( 1 ).'.
-				  list inUIProcessDo: [ list selecter deselectIndexes: #( 1 ) ].
+				  list deferOrValue: [ list selecter deselectIndexes: #( 1 ) ].
 				
 				  self storeRunnedAction:
 					  'list selecter selectOnlyIndexes: #( 1 ).'.
-				  list inUIProcessDo: [ list selecter selectOnlyIndexes: #( 1 ) ].
+				  list deferOrValue: [ list selecter selectOnlyIndexes: #( 1 ) ].
 
 				  self storeRunnedAction:
 					  'list dataAccessor addAll: (1 to: size).'.
-				  list inUIProcessDo: [ list dataAccessor addAll: (1 to: size) ].
+				  list deferOrValue: [ list dataAccessor addAll: (1 to: size) ].
 
 				  self storeRunnedAction: 'list selecter selectAll.'.
-				  list inUIProcessDo: [ list selecter selectAll ].
+				  list deferOrValue: [ list selecter selectAll ].
 				
 				  self storeRunnedAction: 'list selecter deselectAll.'.
-				  list inUIProcessDo: [ list selecter deselectAll ].
+				  list deferOrValue: [ list selecter deselectAll ].
 				
 				  self storeRunnedAction: 'list selecter selectIndex: 3.'.
-				  list inUIProcessDo: [ list selecter selectIndex: 3 ] ].
+				  list deferOrValue: [ list selecter selectIndex: 3 ] ].
 		  endTime := DateAndTime now.
 		  (endTime - startTime) asDuration traceCr ]
 ]

--- a/src/Toplo-Examples/ToTopLevelMockTest.class.st
+++ b/src/Toplo-Examples/ToTopLevelMockTest.class.st
@@ -7,15 +7,7 @@ Class {
 { #category : #tests }
 ToTopLevelMockTest >> closeWindows [
 
-	{
-		BlOSWindowSDL2Host.
-		BlMorphicWindowHost } do: [ :host |
-			host universe closeSpaces.
-			host
-				stop;
-				start ].
-	BlSpace allInstances do: [ :each | each close ].
-	BlParallelUniverse all do: [ :each | each closeSpaces ]
+	Toplo closeSpaces
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/TToDirectionalTest.class.st
+++ b/src/Toplo-Tests/TToDirectionalTest.class.st
@@ -20,14 +20,15 @@ TToDirectionalTest >> setUp [
 	pane := ToPane new.
 	dirCpt := 0.
 	pane addEventHandler: (BlEventHandler
-			 on: ToLayoutDirectionChangedEvent
-			 do: [ dirCpt := dirCpt + 1 ]).
-	space root addChild: pane.
-	child1 := ToElement new.
-	child2 := ToElement new.
-	pane addChildren: {
+		on: ToLayoutDirectionChangedEvent
+		do: [ dirCpt := dirCpt + 1 ]).
+	space deferAndSettle: [
+		space root addChild: pane.
+		child1 := ToElement new.
+		child2 := ToElement new.
+		pane addChildren: {
 			child1.
-			child2 }
+			child2 } ]
 ]
 
 { #category : #tests }
@@ -35,19 +36,19 @@ TToDirectionalTest >> testBeLeftToRight [
 
 	| dcpt |
 	" to be sure pane is leftToRight"
-	pane beLeftToRight.
+	space deferAndSettle: [ pane beLeftToRight ].
 	dcpt := dirCpt.
-	pane beLeftToRight.
+	space deferAndSettle: [ pane beLeftToRight ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane beRightToLeft.
+
+	space deferAndSettle: [ pane beRightToLeft ].
 	dcpt := dirCpt.
-	pane beLeftToRight.
+	space deferAndSettle: [ pane beLeftToRight ].
 	" direction chaged -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isLeftToRight.
 	self assert: pane isRightToLeft not.
-	self waitTestingSpaces.
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
@@ -57,19 +58,19 @@ TToDirectionalTest >> testBeRightToLeft [
 
 	| dcpt |
 	" to be sure pane is leftToRight"
-	pane beRightToLeft.
+	space deferAndSettle: [ pane beRightToLeft ].
 	dcpt := dirCpt.
-	pane beRightToLeft.
+	space deferAndSettle: [ pane beRightToLeft ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane beLeftToRight.
+
+	space deferAndSettle: [ pane beLeftToRight ].
 	dcpt := dirCpt.
-	pane beRightToLeft.
+	space deferAndSettle: [ pane beRightToLeft ].
 	" direction chaged -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isRightToLeft.
 	self assert: pane isLeftToRight not.
-	self waitTestingSpaces.
 	self assert: child2 bounds right equals: child1 bounds left.
 	self assert: child2 bounds top equals: child1 bounds top
 ]
@@ -78,39 +79,38 @@ TToDirectionalTest >> testBeRightToLeft [
 TToDirectionalTest >> testDirection [
 
 	| dcpt |
-	pane direction: BlLayoutDirection rightToLeft.
+	space deferAndSettle: [ pane direction: BlLayoutDirection rightToLeft ].
 	dcpt := dirCpt.
 	" sure pane is rightToLeft -> no event sent "
-	pane direction: BlLayoutDirection rightToLeft.
+	space deferAndSettle: [ pane direction: BlLayoutDirection rightToLeft ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane direction: BlLayoutDirection leftToRight.
+
+	space deferAndSettle: [ pane direction: BlLayoutDirection leftToRight ].
 	dcpt := dirCpt.
-	pane direction: BlLayoutDirection rightToLeft.
+	space deferAndSettle: [ pane direction: BlLayoutDirection rightToLeft ].
 	" direction changed -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isRightToLeft.
 	self assert: pane isLeftToRight not.
-	self waitTestingSpaces.
 	self assert: child2 bounds right equals: child1 bounds left.
 	self assert: child2 bounds top equals: child1 bounds top.
 
 	" now for the inverted direction "
-	pane direction: BlLayoutDirection leftToRight.
+	space deferAndSettle: [ pane direction: BlLayoutDirection leftToRight ].
 	dcpt := dirCpt.
 	" sure pane is leftToRight -> no event sent "
-	pane direction: BlLayoutDirection leftToRight.
+	space deferAndSettle: [ pane direction: BlLayoutDirection leftToRight ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane direction: BlLayoutDirection rightToLeft.
+
+	space deferAndSettle: [ pane direction: BlLayoutDirection rightToLeft ].
 	dcpt := dirCpt.
-	pane direction: BlLayoutDirection leftToRight.
+	space deferAndSettle: [ pane direction: BlLayoutDirection leftToRight ].
 	" direction chaged -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isLeftToRight.
 	self assert: pane isRightToLeft not.
-
-	self waitTestingSpaces.
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
@@ -118,23 +118,27 @@ TToDirectionalTest >> testDirection [
 { #category : #tests }
 TToDirectionalTest >> testIsLeftToRight [
 
-	pane beLeftToRight.
-	pane beRightToLeft.
-	pane beLeftToRight.
+	space deferAndSettle: [
+		pane beLeftToRight.
+		pane beRightToLeft.
+		pane beLeftToRight ].
 	self assert: pane isLeftToRight.
-	pane beRightToLeft.
-	self assert: pane isLeftToRight not.
+
+	space deferAndSettle: [ pane beRightToLeft ].
+	self assert: pane isLeftToRight not
 ]
 
 { #category : #tests }
 TToDirectionalTest >> testIsRightToLeft [
 
-	pane beRightToLeft.
-	pane beLeftToRight.
-	pane beRightToLeft.
+	space deferAndSettle: [
+		pane beRightToLeft.
+		pane beLeftToRight.
+		pane beRightToLeft ].
 	self assert: pane isRightToLeft.
-	pane beLeftToRight.
-	self assert: pane isRightToLeft not.
+
+	space deferAndSettle: [ pane beLeftToRight ].
+	self assert: pane isRightToLeft not
 ]
 
 { #category : #tests }
@@ -142,19 +146,19 @@ TToDirectionalTest >> testLeftToRight [
 
 	| dcpt |
 	" to be sure pane is leftToRight"
-	pane leftToRight: true.
+	space deferAndSettle: [ pane leftToRight: true ].
 	dcpt := dirCpt.
-	pane leftToRight: true.
+	space deferAndSettle: [ pane leftToRight: true ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane leftToRight: false.
+
+	space deferAndSettle: [ pane leftToRight: false ].
 	dcpt := dirCpt.
-	pane leftToRight: true.
+	space deferAndSettle: [ pane leftToRight: true ].
 	" direction chaged -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isLeftToRight.
 	self assert: pane isRightToLeft not.
-	self waitTestingSpaces.
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
@@ -164,19 +168,19 @@ TToDirectionalTest >> testRightToLeft [
 
 	| dcpt |
 	" to be sure pane is leftToRight"
-	pane rightToLeft: true.
+	space deferAndSettle: [ pane rightToLeft: true ].
 	dcpt := dirCpt.
-	pane rightToLeft: true.
+	space deferAndSettle: [ pane rightToLeft: true ].
 	" no event sent "
 	self assert: dirCpt equals: dcpt.
-	pane rightToLeft: false.
+
+	space deferAndSettle: [ pane rightToLeft: false ].
 	dcpt := dirCpt.
-	pane rightToLeft: true.
+	space deferAndSettle: [ pane rightToLeft: true ].
 	" direction chaged -> and event is sent "
 	self assert: dirCpt equals: dcpt + 1.
 	self assert: pane isRightToLeft.
 	self assert: pane isLeftToRight not.
-	self waitTestingSpaces.
 	self assert: child2 bounds right equals: child1 bounds left.
 	self assert: child2 bounds top equals: child1 bounds top
 ]
@@ -185,9 +189,9 @@ TToDirectionalTest >> testRightToLeft [
 TToDirectionalTest >> testVerticalRightToLeft [
 
 	" to be sure pane is leftToRight"
-	pane rightToLeft: true.
-	pane vertical: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		pane rightToLeft: true.
+		pane vertical: true ].
 	self assert: child2 bounds left equals: child1 bounds left.
 	self assert: child2 bounds bottom equals: child1 bounds top
 ]

--- a/src/Toplo-Tests/TToElementWithActionPoolTest.class.st
+++ b/src/Toplo-Tests/TToElementWithActionPoolTest.class.st
@@ -15,7 +15,7 @@ TToElementWithActionPoolTest >> setUp [
 
 	super setUp.
 	element := ToElement new extent: 50 asPoint.
-	space root addChild: element
+	space deferAndSettle: [ space root addChild: element ]
 ]
 
 { #category : #tests }
@@ -23,17 +23,18 @@ TToElementWithActionPoolTest >> testCheckAction [
 
 	| received checkable |
 	received := nil.
-	checkable := ToCheckbox new labelText: 'XXXXX'; yourself.
-	space root addChild: checkable.
+	checkable := ToCheckbox labelText: 'XXXXX'.
 	checkable checkAction: [ :evt | received := evt ].
+	space deferAndSettle: [ space root addChild: checkable ].
+
 	checkable dispatchEvent: (ToCheckableChangedEvent new
 			 checked: true;
 			 yourself).
 	self assert: (received isKindOf: ToCheckableChangedEvent).
-	received := nil.
-	BlSpace simulateClickOn: checkable.
-	self assert: (received isKindOf: ToCheckableChangedEvent).
 
+	received := nil.
+	checkable eventSimulator click.
+	self assert: (received isKindOf: ToCheckableChangedEvent)
 ]
 
 { #category : #tests }
@@ -42,14 +43,11 @@ TToElementWithActionPoolTest >> testCheckActionWith [
 	| received checkable value |
 	received := nil.
 	value := nil.
-	checkable := ToCheckbox new
-		             labelText: 'XXXXX';
-		             yourself.
-	space root addChild: checkable.
-	checkable
-		checkAction: [ :evt |
-				received := evt.
-				value := evt target isChecked ].
+	checkable := ToCheckbox labelText: 'XXXXX'.
+	space deferAndSettle: [ space root addChild: checkable ].
+	checkable checkAction: [ :evt |
+		received := evt.
+		value := evt target isChecked ].
 	checkable dispatchEvent: (ToCheckableChangedEvent checked: true).
 	self assert: (received isKindOf: ToCheckableChangedEvent).
 	self deny: value.
@@ -66,8 +64,7 @@ TToElementWithActionPoolTest >> testClickAction [
 	| received |
 	received := nil.
 	element clickAction: [ :evt | received := evt ].
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: received notNil
 	
 ]
@@ -79,8 +76,7 @@ TToElementWithActionPoolTest >> testClickAction2 [
 	received := nil.
 	element clickAction: [ :evt |
 			received := evt ].
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: received notNil
 ]
 
@@ -91,9 +87,7 @@ TToElementWithActionPoolTest >> testGroupCheckAction [
 	group := ToCheckableGroupPane new.
 	group withStrictCheckingStrategy.
 	{ 'Monday'. 'Tuesday'. 'Wednesday'. 'Thursday'. 'Friday' } do: [ :day |
-			group addChild: (ToToggleButton new
-					 labelText: day;
-					 yourself) ].
+			group addChild: (ToToggleButton labelText: day) ].
 
 	group
 		groupCheckAction: [ :evt  |
@@ -102,9 +96,9 @@ TToElementWithActionPoolTest >> testGroupCheckAction [
 				theList := evt checkedList ].
 
 	group width: 150.
-	space root addChild: group.
-	group items second checked: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: group.
+		group items second checked: true ].
 	self assert: received notNil.
 	self assert: theGroup identicalTo: group.
 	self assert: theList size equals: 1.
@@ -119,27 +113,27 @@ TToElementWithActionPoolTest >> testNewCheckAction [
 	| received prevReceived action passedInAction checkable |
 	received := nil.
 	passedInAction := false.
-	checkable := ToCheckbox new
-		             labelText: 'XXXXX';
-		             yourself.
-	space root addChild: checkable.
+	checkable := ToCheckbox labelText: 'XXXXX'.
 	action := checkable newCheckAction: [ :evt |
 			          received := evt.
 			          passedInAction := true ].
 	self assert: action notNil.
-	BlSpace simulateClickOn: checkable.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ space root addChild: checkable ].
+	checkable eventSimulator click.
 	self assert: received notNil.
 	self assert: passedInAction.
+
 	prevReceived := received.
 	received := nil.
 	passedInAction := false.
-	action requestNextRun.
+	space deferAndSettle: [ action requestNextRun ].
 	self assert: received isNil.
 	self assert: passedInAction.
+
 	received := nil.
 	passedInAction := false.
-	action requestNextRunWithEvent: prevReceived.
+	space deferAndSettle: [ action requestNextRunWithEvent: prevReceived ].
 	self assert: received equals: prevReceived.
 	self assert: passedInAction
 ]
@@ -154,8 +148,7 @@ TToElementWithActionPoolTest >> testNewClickAction [
 			          received := evt.
 			          passedInAction := true ].
 	self assert: action notNil.
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: received notNil.
 	self assert: passedInAction.
 	prevReceived := received.
@@ -178,9 +171,7 @@ TToElementWithActionPoolTest >> testNewGroupCheckAction [
 	group := ToCheckableGroupPane new.
 
 	{ 'Monday'. 'Tuesday'. 'Wednesday'. 'Thursday'. 'Friday' } do: [ :day |
-			group addChild: (ToToggleButton new
-					 labelText: day;
-					 yourself) ].
+			group addChild: (ToToggleButton labelText: day) ].
 
 	group newGroupCheckAction: [ :evt |
 			received := evt.
@@ -188,11 +179,10 @@ TToElementWithActionPoolTest >> testNewGroupCheckAction [
 			theList := evt checkedList ].
 	
 	group width: 150.
-	space root addChild: group.
-	" wait to update the data source "
-	self waitTestingSpaces.
-	group items second checked: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: group.
+		group items second checked: true ].
+	" waited to update the data source "
 	self assert: received notNil.
 	self assert: theGroup identicalTo: group.
 	self assert: theList size equals: 1.
@@ -206,11 +196,9 @@ TToElementWithActionPoolTest >> testRunCount [
 	count := 0.
 	actionLink := element newClickAction: [ :evt | count := count + 1 ].
 	self assert: actionLink runCount equals: 0.
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: actionLink runCount equals: count.
-	self assert: actionLink runCount equals: 1.
-	
+	self assert: actionLink runCount equals: 1
 ]
 
 { #category : #tests }
@@ -220,13 +208,11 @@ TToElementWithActionPoolTest >> testRunCount2 [
 	count := 0.
 	actionLink := element newClickAction: [ :evt | count := count + 1 ].
 	self assert: actionLink runCount equals: 0.
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: actionLink runCount equals: count.
 	self assert: actionLink runCount equals: 1.
 	(BlMouseProcessor dblClickDelay + 1 milliSecond) wait.
-	BlSpace simulateClickOn: element.
-	self waitTestingSpaces.
+	element eventSimulator click.
 	self assert: actionLink runCount equals: count.
 	self assert: actionLink runCount equals: 2
 ]

--- a/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
+++ b/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
@@ -9,20 +9,22 @@ TToElementWithContextMenuTest >> testContextMenu [
 
 	| tt e ttwin |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e hasContextMenu.
-	e contextMenuBuilder: [ :win :theElement |
-		win addItem: (tt := ToMenuItem new) ].
+
+	space deferAndSettle: [ e contextMenuBuilder: [ :win :theElement |
+		win addItem: (tt := ToMenuItem new) ] ].
 	self deny: e hasContextMenu.
 	self assert: e rawContextMenuManager notNil.
+
 	ttwin := e newContextMenuOnEvent: nil.
 	self assert: e currentContextMenu identicalTo: ttwin.
-	ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0) ].
 	self assert: ttwin root firstChild nodes first item identicalTo: tt.
 	self assert: ttwin anchorElement identicalTo: e.
-	ttwin close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ ttwin close ].
 	^ e
 ]
 
@@ -32,7 +34,7 @@ TToElementWithContextMenuTest >> testContextMenuAddItem [
 
 	| e ttwin |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e currentContextMenu isNil.
 	self assert: e rawContextMenuManager isNil.
 	e contextMenuBuilder: [ :win :theElement |
@@ -41,8 +43,8 @@ TToElementWithContextMenuTest >> testContextMenuAddItem [
 	ttwin := e newContextMenuOnEvent: nil.
 	self assert: ttwin isClosed.
 	self assert: ttwin root hasChildren.
-	ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0) ].
 	self assert: ttwin isOpened.
 	self assert: ttwin root hasChildren.
 	self assert: e ensuredContextMenuManager currentWindow notNil.
@@ -51,12 +53,12 @@ TToElementWithContextMenuTest >> testContextMenuAddItem [
 	self
 		assert: e currentContextMenu
 		identicalTo: e ensuredContextMenuManager currentWindow.
-	ttwin close.
+
+	space deferAndSettle: [ ttwin close ].
 	self assert: ttwin isClosed.
 	self assert: e currentContextMenu isNil.
 	self assert: e ensuredContextMenuManager currentWindow isNil.
-	self assert: e ensuredContextMenuManager anchorElement identicalTo: e.
-	^ e
+	self assert: e ensuredContextMenuManager anchorElement identicalTo: e
 ]
 
 { #category : #tests }
@@ -70,7 +72,8 @@ TToElementWithContextMenuTest >> testContextMenuBuilder [
 	self
 		assert: e rawContextMenuManager windowBuilder
 		identicalTo: b.
-	e removeContextMenuBuilder.
+	
+	space deferAndSettle: [ e removeContextMenuBuilder ].
 	self assert: e rawContextMenuManager isNil
 ]
 
@@ -80,16 +83,17 @@ TToElementWithContextMenuTest >> testContextMenuBuilder2 [
 	| e ttwin |
 	e := self testContextMenu.
 	self assert: e ensuredContextMenuManager currentWindow isNil.
-	ttwin := e newContextMenuOnEvent: BlMouseDownEvent new.
-	ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		ttwin := e newContextMenuOnEvent: BlMouseDownEvent new.
+		ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0) ].
 	self assert: ttwin root firstChild notNil.
-	e removeContextMenuBuilder.
+
+	space deferAndSettle: [ e removeContextMenuBuilder ].
 	self assert: e currentContextMenu isNil.
 	self assert: e hasContextMenu not.
-	self waitTestingSpaces.
-	self should: [ ttwin close ] raise: Error.
-	^ e
+
+	self should: [ ttwin close ] raise: Error
 ]
 
 { #category : #tests }
@@ -111,9 +115,10 @@ TToElementWithContextMenuTest >> testContextMenuCanPopupIfElementInSpace [
 		raise: Error.
 	self assert: ttwin isClosed.
 	self assert: ttwin root hasChildren.
-	space root addChild: e.
-	ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		space root addChild: e.
+		ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0) ].
 	self assert: ttwin isOpened.
 	self assert: ttwin root hasChildren.
 	self assert: e ensuredContextMenuManager currentWindow notNil.
@@ -122,12 +127,12 @@ TToElementWithContextMenuTest >> testContextMenuCanPopupIfElementInSpace [
 	self
 		assert: e currentContextMenu
 		identicalTo: e ensuredContextMenuManager currentWindow.
-	ttwin close.
+	
+	space deferAndSettle: [ ttwin close ].
 	self assert: ttwin isClosed.
 	self assert: e currentContextMenu isNil.
 	self assert: e ensuredContextMenuManager currentWindow isNil.
-	self assert: e ensuredContextMenuManager anchorElement identicalTo: e.
-	^ e
+	self assert: e ensuredContextMenuManager anchorElement identicalTo: e
 ]
 
 { #category : #tests }
@@ -136,12 +141,12 @@ TToElementWithContextMenuTest >> testContextMenuRequest [
 
 	| e ttwin request |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e currentContextMenu isNil.
 	self assert: e rawContextMenuManager isNil.
 	e contextMenuBuilder: [ :win :theRequest |
-			win addItem: ToMenuItem new.
-			request := theRequest ].
+		win addItem: ToMenuItem new.
+		request := theRequest ].
 	ttwin := e newContextMenuOnEvent: nil.
 	self assert: request notNil.
 	self
@@ -188,18 +193,19 @@ TToElementWithContextMenuTest >> testEnsuredContextMenuManager [
 
 	| e ttwin |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e currentContextMenu isNil.
 	self assert: e rawContextMenuManager isNil.
 	e contextMenuBuilder: [ :win :theElement |
 		win addItem: ToMenuItem new ].
 	self assert: e rawContextMenuManager notNil.
 	ttwin := e newContextMenuOnEvent: nil.
-	ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ ttwin popupEvent: (BlMouseDownEvent new position: 0 @ 0) ].
 	self assert: e ensuredContextMenuManager currentWindow notNil.
 	self assert: e ensuredContextMenuManager anchorElement identicalTo: e.
-	ttwin close.
+
+	space deferAndSettle: [ ttwin close ].
 	self assert: e ensuredContextMenuManager currentWindow isNil.
 	self assert: e ensuredContextMenuManager anchorElement identicalTo: e.
 	^ e
@@ -273,6 +279,5 @@ TToElementWithContextMenuTest >> testRemoveContextMenuBuilder [
 	e := self testContextMenu.
 	self assert: e rawContextMenuManager notNil.
 	e removeContextMenuBuilder.
-	self assert: e rawContextMenuManager isNil.
-	^ e
+	self assert: e rawContextMenuManager isNil
 ]

--- a/src/Toplo-Tests/TToElementWithPlaceholderTest.class.st
+++ b/src/Toplo-Tests/TToElementWithPlaceholderTest.class.st
@@ -100,15 +100,21 @@ TToElementWithPlaceholderTest >> testShowPlaceholder [
 	ph := e placeholderLayer.
 	self assert: ph notNil.
 	self assert: ph parent identicalTo: e.
-	e forceLayout.
-	self assert: ph bounds inSpace bounds equals: e bounds inSpace bounds.
-	self assert: ph bounds extent equals: 100 asPoint.
 	e showPlaceholder.
 	self assert: e placeholderLayer identicalTo: ph.
-	space root addChild: e.
+
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: ph space identicalTo: e space.
-	e position: 200 @ 100.
-	e forceLayout.
-	self assert: ph bounds inSpace bounds equals: e bounds inSpace bounds.
-	self assert: ph bounds inSpace bounds origin equals: 200 @ 100
+	self
+		assert: ph bounds inSpace bounds
+		equals: e bounds inSpace bounds.
+	self assert: ph bounds extent equals: 100 asPoint.
+
+	space deferAndSettle: [ e position: 200 @ 100 ].
+	self
+		assert: ph bounds inSpace bounds
+		equals: e bounds inSpace bounds.
+	self
+		assert: ph bounds inSpace bounds origin
+		equals: 200 @ 100
 ]

--- a/src/Toplo-Tests/TToElementWithTooltipTest.class.st
+++ b/src/Toplo-Tests/TToElementWithTooltipTest.class.st
@@ -14,17 +14,17 @@ TToElementWithTooltipTest >> testCloseTooltipOnMouseLeave [
 	e := ToElement new.
 	e extent: 50 @ 50.
 	e tooltipManagerDo: [ :m | m popupDelay: 10 milliSeconds ].
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e currentTooltipWindow isNil.
 	e tooltipBuilder: [ :win :request |
 			win root addChild: (ToElement new
 					 extent: 20 @ 20;
 					 yourself) ].
-	BlSpace simulateMouseMoveInside: e.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 50 milliSeconds.
+	e eventSimulator mouseMoveInside.
+	space waitUntilTrue: [ e currentTooltipWindow notNil ].
 	self assert: e currentTooltipWindow notNil.
-	BlSpace simulateMouseMoveOutside: e.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 11 milliSeconds.
+	e eventSimulator mouseMoveOutside.
+	space waitUntilTrue: [ e currentTooltipWindow isNil ].
 	self assert: e currentTooltipWindow isNil.
 
 	^ e
@@ -38,19 +38,18 @@ TToElementWithTooltipTest >> testCloseTooltipOnMouseLeave2 [
 	e extent: 50 @ 50.
 	e tooltipManagerDo: [ :m | m closeOnLeaved: false ].
 	e tooltipManagerDo: [ :m | m popupDelay: 10 milliSeconds ].
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e currentTooltipWindow isNil.
 	e tooltipBuilder: [ :win :request |
 			win root addChild: (ToElement new
 					 extent: 20 @ 20;
 					 yourself) ].
-	BlSpace simulateMouseMoveInside: e.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 11 milliSeconds.
+	e eventSimulator mouseMoveInside.
+	space waitUntilTrue: [ e currentTooltipWindow notNil ].
 	self assert: e currentTooltipWindow notNil.
-	BlSpace simulateMouseMoveOutside: e.
-	self assert: e currentTooltipWindow notNil.
-
-	^ e
+	e eventSimulator mouseMoveOutside.
+	space waitForDuration: 50 milliSeconds.
+	self assert: e currentTooltipWindow notNil
 ]
 
 { #category : #tests }
@@ -212,23 +211,28 @@ TToElementWithTooltipTest >> testTooltipPopupDelay [
 	e tooltipManagerDo: [ :m |
 			m popupDelay: 100 milliSeconds.
 			self assert: m popupDelay equals: 100 milliSeconds ].
-	space root addChild: e.
-	e tooltipBuilder: [ :win :request |
+
+	space deferAndSettle: [
+		space root addChild: e.
+		e tooltipBuilder: [ :win :request |
 			win root addChild: (ToElement new
 					 extent: 20 @ 20;
-					 yourself) ].
-	BlSpace simulateMouseMoveInside: e.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 50 milliSeconds.
+					 yourself) ] ].
+	
+	e eventSimulator mouseMoveInside.
+	space waitForDuration: 50 milliSeconds.
 	self assert: e currentTooltipWindow isNil.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 51 milliSeconds.
-	self assert: e currentTooltipWindow notNil.
-	BlSpace simulateMouseMoveOutside: e.
-	self assert: e currentTooltipWindow isNil.
-	BlSpace simulateMouseMoveInside: e.
-	BlSpace pulseUntilEmptyTaskQueue: space timeout: 101 milliSeconds.
+
+	space waitUntilTrue: [ e currentTooltipWindow notNil ].
 	self assert: e currentTooltipWindow notNil.
 
-	^ e
+	e eventSimulator mouseMoveOutside.
+	space waitUntilTrue: [ e currentTooltipWindow isNil ].
+	self assert: e currentTooltipWindow isNil.
+
+	e eventSimulator mouseMoveInside.
+	space waitUntilTrue: [ e currentTooltipWindow notNil ].
+	self assert: e currentTooltipWindow notNil
 ]
 
 { #category : #tests }
@@ -238,8 +242,8 @@ TToElementWithTooltipTest >> testTooltipRequestEvent [
 	| tt e ttwin request |
 	tt := BlElement new.
 	e := ToElement new.
-	self assert: e hasTooltip not.
-	e tooltip: [:win :theRequest | win root addChild: tt. request := theRequest].
+	self deny: e hasTooltip.
+	e tooltip: [ :win :theRequest | win root addChild: tt. request := theRequest ].
 	self assert: e hasTooltip.
 	ttwin := e rawTooltipManager createNewWindowOnEvent: nil.
 	self assert: request class identicalTo: ttwin manager windowRequestClass.

--- a/src/Toplo-Tests/TToOrientableTest.class.st
+++ b/src/Toplo-Tests/TToOrientableTest.class.st
@@ -20,14 +20,15 @@ TToOrientableTest >> setUp [
 	pane := ToPane new.
 	oriCpt := 0.
 	pane addEventHandler: (BlEventHandler
-			 on: ToLayoutOrientationChangedEvent
-			 do: [ oriCpt := oriCpt + 1 ]).
-	space root addChild: pane.
-	child1 := ToElement new.
-	child2 := ToElement new.
-	pane addChildren: {
+		on: ToLayoutOrientationChangedEvent
+		do: [ oriCpt := oriCpt + 1 ]).
+	space deferAndSettle: [
+		space root addChild: pane.
+		child1 := ToElement new.
+		child2 := ToElement new.
+		pane addChildren: {
 			child1.
-			child2 }
+			child2 } ]
 ]
 
 { #category : #tests }
@@ -35,63 +36,63 @@ TToOrientableTest >> testBeHorizontal [
 
 	| ocpt |
 	" to be sure pane is horizontal"
-	pane beHorizontal.
+	space deferAndSettle: [ pane beHorizontal ].
 	ocpt := oriCpt.
-	pane beHorizontal.
+	space deferAndSettle: [ pane beHorizontal ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane beVertical.
+
+	space deferAndSettle: [ pane beVertical ].
 	ocpt := oriCpt.
-	pane beHorizontal.
+	space deferAndSettle: [ pane beHorizontal ].
 	" orientation changed -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isHorizontal.
 	self assert: pane isVertical not.
-	self waitTestingSpaces.
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
 
 { #category : #tests }
 TToOrientableTest >> testBeVertical [
-	" to be sure pane is horizontal"
 
 	| ocpt |
-	pane beVertical.
+	" to be sure pane is horizontal"
+	space deferAndSettle: [ pane beVertical ].
 	ocpt := oriCpt.
-	pane beVertical.
+	space deferAndSettle: [ pane beVertical ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane beHorizontal.
+
+	space deferAndSettle: [ pane beHorizontal ].
 	ocpt := oriCpt.
-	pane beVertical.
+	space deferAndSettle: [ pane beVertical ].
 	" orientation chaged -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isVertical.
 	self assert: pane isHorizontal not.
-	self waitTestingSpaces.
 	self assert: child1 bounds bottom equals: child2 bounds top.
 	self assert: child1 bounds left equals: child2 bounds left
 ]
 
 { #category : #tests }
 TToOrientableTest >> testHorizontal [
-	" to be sure pane is horizontal"
 
 	| ocpt |
-	pane horizontal: true.
+	" to be sure pane is horizontal"
+	space deferAndSettle: [ pane horizontal: true ].
 	ocpt := oriCpt.
-	pane horizontal: true.
+	space deferAndSettle: [ pane horizontal: true ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane horizontal: false.
+
+	space deferAndSettle: [ pane horizontal: false ].
 	ocpt := oriCpt.
-	pane horizontal: true.
+	space deferAndSettle: [ pane horizontal: true ].
 	" orientation chaged -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isHorizontal.
 	self assert: pane isVertical not.
-	self waitTestingSpaces.
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
@@ -99,85 +100,90 @@ TToOrientableTest >> testHorizontal [
 { #category : #tests }
 TToOrientableTest >> testIsHorizontal [
 
-	pane beHorizontal.
-	pane beVertical.
-	pane beHorizontal.
+	space deferAndSettle: [
+		pane beHorizontal.
+		pane beVertical.
+		pane beHorizontal ].
 	self assert: pane isHorizontal.
-	pane beVertical.
-	self assert: pane isHorizontal not.
+
+	space deferAndSettle: [ pane beVertical ].
+	self assert: pane isHorizontal not
 ]
 
 { #category : #tests }
 TToOrientableTest >> testIsVertical [
 
-	pane beVertical.
-	pane beHorizontal.
-	pane beVertical.
+	space deferAndSettle: [
+		pane beVertical.
+		pane beHorizontal.
+		pane beVertical ].
 	self assert: pane isVertical.
-	pane beHorizontal.
-	self assert: pane isVertical not.
+
+	space deferAndSettle: [ pane beHorizontal ].
+	self assert: pane isVertical not
 ]
 
 { #category : #tests }
 TToOrientableTest >> testOrientation [
 
 	| ocpt |
-	pane orientation: BlLinearLayoutOrientation vertical.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation vertical ].
 	ocpt := oriCpt.
 	" sure pane is vertical -> no event sent "
-	pane orientation: BlLinearLayoutOrientation vertical.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation vertical ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane orientation: BlLinearLayoutOrientation horizontal.
+
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation horizontal ].
 	ocpt := oriCpt.
-	pane orientation: BlLinearLayoutOrientation vertical.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation vertical ].
 	" orientation chaged -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isVertical.
 	self assert: pane isHorizontal not.
-	self waitTestingSpaces.
 	self assert: child1 bounds bottom equals: child2 bounds top.
 	self assert: child1 bounds left equals: child2 bounds left.
 
 	" now for the inverted orientation "
-	pane orientation: BlLinearLayoutOrientation horizontal.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation horizontal ].
 	ocpt := oriCpt.
 	" sure pane is vertical -> no event sent "
-	pane orientation: BlLinearLayoutOrientation horizontal.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation horizontal ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane orientation: BlLinearLayoutOrientation vertical.
+
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation vertical ].
+
 	ocpt := oriCpt.
-	pane orientation: BlLinearLayoutOrientation horizontal.
+	space deferAndSettle: [ pane orientation: BlLinearLayoutOrientation horizontal ].
 	" orientation chaged -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isHorizontal.
 	self assert: pane isVertical not.
-	pane requestNewSkin.
-	self waitTestingSpaces.
 
+	space deferAndSettle: [ pane requestNewSkin ].
 	self assert: child1 bounds right equals: child2 bounds left.
 	self assert: child1 bounds top equals: child2 bounds top
 ]
 
 { #category : #tests }
 TToOrientableTest >> testVertical [
-	" to be sure pane is horizontal"
 
 	| ocpt |
-	pane vertical: true.
+	" to be sure pane is horizontal"
+	space deferAndSettle: [ pane vertical: true ].
 	ocpt := oriCpt.
-	pane vertical: true.
+	space deferAndSettle: [ pane vertical: true ].
 	" no event sent "
 	self assert: oriCpt equals: ocpt.
-	pane vertical: false.
+
+	space deferAndSettle: [ pane vertical: false ].
 	ocpt := oriCpt.
-	pane vertical: true.
+	space deferAndSettle: [ pane vertical: true ].
 	" orientation chaged -> and event is sent "
 	self assert: oriCpt equals: ocpt + 1.
 	self assert: pane isVertical.
 	self assert: pane isHorizontal not.
-	self waitTestingSpaces.
 	self assert: child1 bounds bottom equals: child2 bounds top.
 	self assert: child1 bounds left equals: child2 bounds left
 ]
@@ -186,9 +192,9 @@ TToOrientableTest >> testVertical [
 TToOrientableTest >> testVerticalRightToLeft [
 
 	" to be sure pane is leftToRight"
-	pane rightToLeft: true.
-	pane vertical: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		pane rightToLeft: true.
+		pane vertical: true ].
 	self assert: child2 bounds left equals: child1 bounds left.
 	self assert: child2 bounds bottom equals: child1 bounds top
 ]

--- a/src/Toplo-Tests/ToAnchoredWindowManagerTest.class.st
+++ b/src/Toplo-Tests/ToAnchoredWindowManagerTest.class.st
@@ -12,17 +12,17 @@ ToAnchoredWindowManagerTest >> testCloseWindow [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :request |  ].
+		:anchWin
+		:request |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: win isOpened.
-	win close.
+
+	space deferAndSettle: [ win close ].
 	self assert: win isClosed
 ]
 
@@ -31,18 +31,19 @@ ToAnchoredWindowManagerTest >> testCurrentWindow [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	self assert: windowManager currentWindow isNil.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: windowManager currentWindow identicalTo: win.
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: windowManager currentWindow identicalTo: win.
-	win close.
+
+	space deferAndSettle: [ win close ].
 	self assert: windowManager currentWindow isNil
 ]
 
@@ -51,21 +52,21 @@ ToAnchoredWindowManagerTest >> testDefaultPositionHook [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self
 		assert: win bounds inSpace bounds origin
 		equals: e bounds inSpace bounds origin.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: e bounds inSpace bounds origin equals: 20 asPoint.
 	self
 		assert: win bounds inSpace bounds origin
@@ -77,14 +78,14 @@ ToAnchoredWindowManagerTest >> testElement [
 
 	| win e openEventFromWindow openEventFromWidget closeEventFromWindow closeEventFromWidget windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :window
-		                 :element |  ].
+		:window
+		:element |  ].
 	e addEventHandler: windowManager.
 	" create the window -> plug-in the window handler "
 	win := windowManager createNewWindowOnEvent: nil.
@@ -94,26 +95,26 @@ ToAnchoredWindowManagerTest >> testElement [
 	" a window handler can be used only for one window  "
 	self should: [ windowManager createNewWindowOnEvent: nil ] raise: Error.
 	win addEventHandler: (BlEventHandler
-			 on: ToOpenedEvent
-			 do: [ :event | openEventFromWindow := event ]).
+		on: ToOpenedEvent
+		do: [ :event | openEventFromWindow := event ]).
 	e addEventHandler: (BlEventHandler
-			 on: ToOpenedEvent
-			 do: [ :event | openEventFromWidget := event ]).
+		on: ToOpenedEvent
+		do: [ :event | openEventFromWidget := event ]).
 	win addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ :event | closeEventFromWindow := event ]).
+		on: ToClosedEvent
+		do: [ :event | closeEventFromWindow := event ]).
 	e addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ :event | closeEventFromWidget := event ]).
+		on: ToClosedEvent
+		do: [ :event | closeEventFromWidget := event ]).
 	self assert: win anchorElement equals: e.
 
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: openEventFromWindow notNil.
 	self assert: openEventFromWindow currentTarget equals: win.
 	self assert: openEventFromWidget notNil.
 	self assert: openEventFromWidget currentTarget equals: e.
-	win close.
+
+	space deferAndSettle: [ win close ].
 	self assert: closeEventFromWindow notNil.
 	self assert: closeEventFromWindow currentTarget equals: win.
 	self assert: closeEventFromWidget notNil.
@@ -125,10 +126,10 @@ ToAnchoredWindowManagerTest >> testElementEventHandler [
 
 	| e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	self assert: (e eventDispatcher handlers includes: windowManager)
 ]
@@ -138,22 +139,21 @@ ToAnchoredWindowManagerTest >> testElementEventHandlerClass [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: win anchorElement equals: e.
 	self assert: (e eventDispatcher hasEventHandlerSuchThat: [ :eh |
-			 eh isKindOf: ToAnchoredWindowManager ]).
-	win close.
+		eh isKindOf: ToAnchoredWindowManager ]).
+
+	space deferAndSettle: [ win close ].
 	self assert: (e eventDispatcher hasEventHandlerSuchThat: [ :eh |
-			 eh isKindOf: ToAnchoredWindowManager ])
+		eh isKindOf: ToAnchoredWindowManager ])
 ]
 
 { #category : #tests }
@@ -161,24 +161,22 @@ ToAnchoredWindowManagerTest >> testElementPositionInSpaceChangedEvent [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 	self assert: e position equals: 10 asPoint.
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self
 		assert: win bounds inSpace bounds origin
 		equals: e bounds inSpace bounds origin.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: e bounds inSpace bounds origin equals: 20 asPoint.
 	self
 		assert: win bounds inSpace bounds origin
@@ -190,24 +188,24 @@ ToAnchoredWindowManagerTest >> testElementToBeRemovedFromParentEvent [
 
 	| win e windowManager closed |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
+	space deferAndSettle: [ win popup ].
 	closed := false.
 	win addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ closed := true ]).
-	self waitTestingSpaces.
+		on: ToClosedEvent
+		do: [ closed := true ]).
 	self assert: win isOpened.
-	space root removeChild: e.
+
+	space deferAndSettle: [ space root removeChild: e ].
 	self assert: closed.
 	self assert: windowManager currentWindow isNil
 ]
@@ -217,18 +215,19 @@ ToAnchoredWindowManagerTest >> testHasWindow [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	self deny: windowManager hasWindow.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: windowManager hasWindow.
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: windowManager hasWindow.
-	win close.
+
+	space deferAndSettle: [ win close ].
 	self deny: windowManager hasWindow
 ]
 
@@ -237,10 +236,10 @@ ToAnchoredWindowManagerTest >> testNewWindowEvent [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	" no element -> Error "
 	self should: [ windowManager createNewWindowOnEvent: nil ] raise: Error.
 	e addEventHandler: windowManager.
@@ -256,7 +255,7 @@ ToAnchoredWindowManagerTest >> testNewWindowEvent2 [
 
 	| win1 e windowManager |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
 	win1 := windowManager createNewWindowOnEvent: nil.
@@ -264,7 +263,7 @@ ToAnchoredWindowManagerTest >> testNewWindowEvent2 [
 	" the window is already built -> Error "
 	self should: [ windowManager createNewWindowOnEvent: nil ] raise: Error.
 	" the window is closed, closing it with #closWindow has no effect "
-	windowManager closeWindow.
+	windowManager closeWindow
 ]
 
 { #category : #tests }
@@ -282,24 +281,22 @@ ToAnchoredWindowManagerTest >> testPositionHook [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self
 		assert: win bounds inSpace bounds origin
 		equals: e bounds inSpace bounds origin.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: e bounds inSpace bounds origin equals: 20 asPoint.
 	self
 		assert: win bounds inSpace bounds origin
@@ -311,31 +308,30 @@ ToAnchoredWindowManagerTest >> testPositionHook2 [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
-	windowManager placement: (ToActionPlacement new
-			 action: [ :window :evt :aBoundsUpdater |
-					 | theElem theRoot |
-					 theElem := window anchorElement.
-					 theRoot := window anchorRoot.
-					 window position: (theElem bounds inParent: theRoot) bottomRight ];
-			 yourself).
+	space deferAndSettle: [ win popup ].
+	space deferAndSettle: [
+		windowManager placement: (ToActionPlacement new
+			action: [ :window :evt :aBoundsUpdater |
+				| theElem theRoot |
+				theElem := window anchorElement.
+				theRoot := window anchorRoot.
+				window position: (theElem bounds inParent: theRoot) bottomRight ];
+			yourself) ].
 	self
 		assert: win bounds inSpace bounds origin
 		equals: e bounds inSpace bounds origin.
-	e position: 50 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 50 asPoint ].
 	self assert: e bounds inSpace bounds origin equals: 50 asPoint.
 	self
 		assert: win bounds inSpace bounds origin
@@ -347,27 +343,25 @@ ToAnchoredWindowManagerTest >> testPositionHook3 [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+		:anchWin
+		:element |  ].
 	e addEventHandler: windowManager.
 	windowManager placement: (ToActionPlacement new
-			 action: [ :theWin :evt :aBoundsUpdater | theWin position: 30 @ 30 ];
-			 yourself).
+		action: [ :theWin :evt :aBoundsUpdater | theWin position: 30 @ 30 ];
+		yourself).
 
 	win := windowManager createNewWindowOnEvent: nil.
 
-	win popup.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: win bounds inSpace bounds origin equals: 30 @ 30.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: e bounds inSpace bounds origin equals: 20 asPoint.
 	self assert: win bounds inSpace bounds origin equals: 30 @ 30
 ]
@@ -377,26 +371,26 @@ ToAnchoredWindowManagerTest >> testWindowBuilder [
 
 	| win e windowManager builder |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	builder := [ :theWindow :theElement |
-		           | child |
-		           child := ToElement new
-			                    extent: 100 asPoint;
-			                    id: #child.
-		           child background: Color red.
-		           theWindow root addChild: child ].
+		| child |
+		child := ToElement new
+			extent: 100 asPoint;
+			id: #child.
+		child background: Color red.
+		theWindow root addChild: child ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder:
-		                 builder.
+		builder.
 	self assert: windowManager windowBuilder identicalTo: builder.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: win root children size equals: 1.
 	self assert: win root firstChild id asSymbol identicalTo: #child.
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: win bounds extent equals: 100 asPoint.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: win bounds extent equals: 100 asPoint
 ]
 

--- a/src/Toplo-Tests/ToAnchoredWindowTest.class.st
+++ b/src/Toplo-Tests/ToAnchoredWindowTest.class.st
@@ -12,23 +12,25 @@ ToAnchoredWindowTest >> testClose [
 
 	| win e windowManager winRootChild |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 	winRootChild := ToElement new.
 
-	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element | anchWin root addChild: winRootChild ].
+	windowManager :=
+		ToAnchoredWindowManagerForTest new
+			windowBuilder: [ :anchWin :element |
+				anchWin root addChild: winRootChild ];
+			yourself.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: winRootChild parent identicalTo: win root.
 	self deny: win isOpened.
+
 	" can't close a closed window "
 	self should: [ win close ] raise: Error.
 	windowManager closeWindow.
 	" but after it has been closed, it can't be opened anymore "
-	win popup
+	space deferAndSettle: [ win popup ].
+
 ]
 
 { #category : #tests }
@@ -36,21 +38,22 @@ ToAnchoredWindowTest >> testClosedEventClass [
 
 	| win windowManager e closeEvent |
 	e := ToElement new.
-	space root addChild: e.
-	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+	space deferAndSettle: [ space root addChild: e ].
+	windowManager :=
+		ToAnchoredWindowManagerForTest new
+			windowBuilder: [ :anchWin :element |  ];
+			yourself.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	win addEventHandler: (BlEventHandler
 			 on: ToClosedEvent
 			 do: [ :event | closeEvent := event ]).
 	self assert: closeEvent isNil.
-	win popup.
-	self waitTestingSpaces.
-	win close.
+
+	space deferAndSettle: [ win popup ].
+
 	" need to wait space pulsing "
-	self waitTestingSpaces.
+	space deferAndSettle: [ win close ].
 	self assert: closeEvent notNil
 ]
 
@@ -59,17 +62,18 @@ ToAnchoredWindowTest >> testDefaultElevation [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
 		                 :anchWin
 		                 :element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	win popup.
+
+	space deferAndSettle: [
+		e position: 10 asPoint.
+		e extent: 10 asPoint.
+		win popup ].
 	self
 		assert: win elevation elevation
 		equals: win defaultElevation elevation
@@ -80,9 +84,7 @@ ToAnchoredWindowTest >> testDispatchClosedEvent [
 
 	| win e windowManager closedEventReceivedByWin closedEventReceivedByElement |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -93,10 +95,10 @@ ToAnchoredWindowTest >> testDispatchClosedEvent [
 	e addEventHandler: (BlEventHandler
 			 on: ToClosedEvent
 			 do: [ :event | closedEventReceivedByElement := event ]).
-	win popup.
-	self waitTestingSpaces.
-	win close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		win popup .
+		win close ].
 	self assert: closedEventReceivedByWin notNil.
 	self assert: closedEventReceivedByElement notNil
 ]
@@ -106,8 +108,7 @@ ToAnchoredWindowTest >> testDispatchOpenedEvent [
 
 	| win e windowManager openedEventReceivedByWin openedEventReceivedByElement |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -118,8 +119,8 @@ ToAnchoredWindowTest >> testDispatchOpenedEvent [
 	e addEventHandler: (BlEventHandler
 			 on: ToOpenedEvent
 			 do: [ :event | openedEventReceivedByElement := event ]).
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: openedEventReceivedByWin notNil.
 	self assert: openedEventReceivedByElement notNil
 ]
@@ -131,8 +132,7 @@ ToAnchoredWindowTest >> testElement [
 	win := ToAnchoredWindow new.
 	self deny: win hasManager.
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -148,8 +148,7 @@ ToAnchoredWindowTest >> testHasAssociateElement [
 	self deny: win hasManager.
 	self should: [ win popup ] raise: Error.
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -162,18 +161,17 @@ ToAnchoredWindowTest >> testLocalThemeSetOnPopupEvent [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: win localTheme isNil.
-	win popupEvent: nil.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popupEvent: nil ].
 	self assert: win lookupTheme identicalTo: e lookupTheme.
-	win close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win close ].
 	self assert: win lookupTheme identicalTo: e lookupTheme.
 ]
 
@@ -182,8 +180,7 @@ ToAnchoredWindowTest >> testLocalThemeSetOnPopupEvent2 [
 
 	| win e windowManager localTheme |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -192,13 +189,13 @@ ToAnchoredWindowTest >> testLocalThemeSetOnPopupEvent2 [
 	localTheme := ToRawDarkTheme new.
 	" Even the win localTheme is set directly, 
 	the actual win localTheme is the theme found from the element"
-	win localTheme: localTheme.
-	win popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		win localTheme: localTheme.
+		win popupEvent: nil ].
 	self assert: win localTheme identicalTo: localTheme.
 	self assert: win lookupTheme identicalTo: localTheme.
-	win close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win close ].
 	self assert: win localTheme identicalTo: localTheme.
 ]
 
@@ -210,8 +207,7 @@ ToAnchoredWindowTest >> testManager [
 	self assert: win manager isNil.
 	self should: [ win popup ] raise: Error.
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -224,8 +220,7 @@ ToAnchoredWindowTest >> testOnOpened [
 
 	| win e windowManager openedEventReceivedByWin openedEventReceivedByElement |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -236,8 +231,8 @@ ToAnchoredWindowTest >> testOnOpened [
 	e addEventHandler: (BlEventHandler
 			 on: ToOpenedEvent
 			 do: [ :event | openedEventReceivedByElement := event ]).
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: openedEventReceivedByWin notNil.
 	self assert: openedEventReceivedByElement notNil
 ]
@@ -247,7 +242,8 @@ ToAnchoredWindowTest >> testOpenedEventClass [
 
 	| win windowManager e openedEvent |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
+
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
 		                 :anchWin
 		                 :element |  ].
@@ -257,9 +253,9 @@ ToAnchoredWindowTest >> testOpenedEventClass [
 			 on: ToOpenedEvent
 			 do: [ :event | openedEvent := event ]).
 	self assert: openedEvent isNil.
-	win popup.
+
+	space deferAndSettle: [ win popup ].
 	" need to wait space pulsing "
-	self waitTestingSpaces.
 	self assert: openedEvent notNil
 ]
 
@@ -268,15 +264,13 @@ ToAnchoredWindowTest >> testPopup [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: win isOpened.
 	self assert: win parent notNil
 ]
@@ -286,9 +280,7 @@ ToAnchoredWindowTest >> testPopupEvent [
 
 	| win e windowManager openedEvent sourceEvent |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new.
 	e addEventHandler: windowManager.
@@ -296,17 +288,15 @@ ToAnchoredWindowTest >> testPopupEvent [
 	win addEventHandler: (BlEventHandler
 			 on: ToOpenedEvent
 			 do: [ :event | openedEvent := event ]).
-	win popupEvent: nil.
-	self waitTestingSpaces.
-	win close.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		win popupEvent: nil .
+		win close ].
 	sourceEvent := BlEvent new.
 	win := windowManager createNewWindowOnEvent: nil.
 	win addEventHandler: (BlEventHandler
 			 on: ToOpenedEvent
 			 do: [ :event | openedEvent := event ]).
-	win popupEvent: sourceEvent.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popupEvent: sourceEvent ].
 	self assert: openedEvent class equals: win openedEventClass
 ]
 
@@ -321,27 +311,23 @@ ToAnchoredWindowTest >> testPopupEventNotInSpace [
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	self assert: win hasAnchorElement.
-	win addEventHandler: (BlEventHandler
-			 on: ToOpenedEvent
-			 do: [ :event | openEventFromWindow := event ]).
-	e addEventHandler: (BlEventHandler
-			 on: ToOpenedEvent
-			 do: [ :event | openEventFromWidget := event ]).
-	win addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ :event | closeEventFromWindow := event ]).
-	e addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ :event | closeEventFromWidget := event ]).
-
+	win addEventHandlerOn: ToOpenedEvent
+			do: [ :event | openEventFromWindow := event ].
+	e addEventHandlerOn: ToOpenedEvent
+			do: [ :event | openEventFromWidget := event ].
+	win addEventHandlerOn: ToClosedEvent
+			do: [ :event | closeEventFromWindow := event ].
+	e addEventHandlerOn: ToClosedEvent
+			do: [ :event | closeEventFromWidget := event ].
 	self should: [ win popup ] raise: Error.
 	self assert: win isOpened not.
 	self assert: openEventFromWindow isNil.
 	self assert: openEventFromWidget isNil.
-	space root addChild: e.
-	win popup.
-	self waitTestingSpaces.
-	win close.
+
+	space deferAndSettle: [
+		space root addChild: e .
+		win popup .
+		win close ].
 	self assert: closeEventFromWindow notNil.
 	self assert: closeEventFromWidget notNil
 ]
@@ -356,7 +342,6 @@ ToAnchoredWindowTest >> testPopupEventNotInSpace2 [
 		                 :element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	self waitTestingSpaces.
 	self should: [ win popup ] raise: Error.
 	self assert: win isOpened not.
 	self assert: win isClosed
@@ -376,27 +361,26 @@ ToAnchoredWindowTest >> testPopupTimestamp [
 
 	| win windowManager e openedEvent timeStamp |
 	e := ToElement new.
-	space root addChild: e.
-	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+	space deferAndSettle: [ space root addChild: e ].
+
+	windowManager :=
+		ToAnchoredWindowManagerForTest new
+			windowBuilder: [ :anchWin :element | ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win addEventHandler: (BlEventHandler
-			 on: ToOpenedEvent
-			 do: [ :event | openedEvent := event ]).
+	win addEventHandlerOn: ToOpenedEvent
+			 do: [ :event | openedEvent := event ].
 	self assert: openedEvent isNil.
 	self assert: win popupTimestamp isNil.
-	win popup.
-	self waitTestingSpaces.
 
+	space deferAndSettle: [ win popup ].
 	self assert: win popupTimestamp notNil.
 	timeStamp := win popupTimestamp.
 	self assert: win popupTimestamp <= DateAndTime now.
 	self assert: win isOpened.
 	self assert: win isClosed not.
-	win close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win close ].
 	self assert: win popupTimestamp equals: timeStamp.
 	self assert: win isOpened not.
 	self assert: win isClosed
@@ -408,7 +392,7 @@ ToAnchoredWindowTest >> testValueOfTokenNamedInWindow [
 	| win e windowManager lab notFoundDispatched |
 	e := ToElement new.
 	e localTheme: ToRawThemeForTest new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
 			                 :anchWin
 			                 :requestEvent |
@@ -416,8 +400,8 @@ ToAnchoredWindowTest >> testValueOfTokenNamedInWindow [
 			                 anchWin root addChild: lab ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popupEvent: nil.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popupEvent: nil ].
 	self
 		assert: (e valueOfTokenNamed: #'test-background-color')
 		equals: Color white.
@@ -426,8 +410,8 @@ ToAnchoredWindowTest >> testValueOfTokenNamedInWindow [
 	self
 		assert: (lab valueOfTokenNamed: #'test-background-color')
 		equals: Color white.
-	win close.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win close ].
 	self
 		assert: (e valueOfTokenNamed: #'test-background-color')
 		equals: Color white.
@@ -457,10 +441,9 @@ ToAnchoredWindowTest >> testWindowSize [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
 	e position: 10 asPoint.
 	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManagerForTest new windowBuilder: [
 		                 :anchWin
@@ -471,16 +454,16 @@ ToAnchoredWindowTest >> testWindowSize [
 	self assert: win constraints vertical resizer isFitContent.
 	self assert: win root constraints horizontal resizer isFitContent.
 	self assert: win root constraints vertical resizer isFitContent.
-	win popup.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ win popup ].
 	self assert: win constraints horizontal resizer isFitContent.
 	self assert: win constraints vertical resizer isFitContent.
 	self assert: win root constraints horizontal resizer isFitContent.
 	self assert: win root constraints vertical resizer isFitContent.
 	self assert: win bounds inSpace extent equals: 0 @ 0.
 	self assert: win root bounds inSpace extent equals: 0 @ 0.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self
 		assert: win bounds inSpace bounds origin
 		equals: e bounds inSpace bounds origin.

--- a/src/Toplo-Tests/ToBasicWindowElementTest.class.st
+++ b/src/Toplo-Tests/ToBasicWindowElementTest.class.st
@@ -13,9 +13,11 @@ ToBasicWindowElementTest >> testClose [
 	| w |
 	w := ToBasicWindowElement new.
 	self assert: w isClosed.
-	space root addChild: w.
+
+	space deferAndSettle: [ space root addChild: w ].
 	self deny: w isClosed.
-	w close.
+
+	space deferAndSettle: [ w close ].
 	self assert: w isClosed.
 	self deny: w isOpened 
 
@@ -54,7 +56,8 @@ ToBasicWindowElementTest >> testIsClosed [
 	| w |
 	w := ToBasicWindowElement new.
 	self assert: w isClosed.
-	space root addChild: w.
+
+	space deferAndSettle: [ space root addChild: w ].
 	self deny: w isClosed
 ]
 
@@ -64,7 +67,8 @@ ToBasicWindowElementTest >> testIsOpened [
 	| w |
 	w := ToBasicWindowElement new.
 	self assert: w isClosed.
-	space root addChild: w.
+
+	space deferAndSettle: [ space root addChild: w ].
 	self assert: w isOpened
 ]
 

--- a/src/Toplo-Tests/ToBlElementTest.class.st
+++ b/src/Toplo-Tests/ToBlElementTest.class.st
@@ -28,8 +28,6 @@ ToBlElementTest >> testAddAllStamps [
 	self assert: (element hasStamp: #color).	
 	self assert: (element hasStamp: #background).
 	self assert: (element hasStamp: #blob).
-
-
 ]
 
 { #category : #'tests - token properties' }
@@ -50,7 +48,6 @@ ToBlElementTest >> testAddAllTokenProperties [
 	self assert: element  tokenPropertyMap size equals: 2.
 	self assert: (element tokenPropertyMap propertyNamed: #color1) value equals: Color white.
 	self assert: (element tokenPropertyMap propertyNamed: #color2) value equals: Color yellow.
-
 ]
 
 { #category : #'tests - stamp' }
@@ -68,7 +65,6 @@ ToBlElementTest >> testAddStamp [
 	self assert: (element hasStamp: #color).	
 	self assert: (element hasStamp: #background).
 	self assert: (element hasStamp: #blob)
-
 ]
 
 { #category : #'tests - token properties' }
@@ -105,12 +101,10 @@ ToBlElementTest >> testApplicableListenersFor [
 
 	| theme |
 	theme := ToStyleSheetThemeForTest new.
-	space toTheme: theme.
-	space root addChild: element.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: element ].
 	self assert: (theme applicableListenersFor: element) size equals: 0
-	
 ]
 
 { #category : #tests }
@@ -119,14 +113,9 @@ ToBlElementTest >> testBlElementShouldNotHaveSkinManager [
 	element background: Color red.
 	element border: Color black.
 	self assert: element skinManager isNil.
-	space root addChild: element.
-	self assert: element skinManager isNil.
-	self waitTestingSpaces.
-	self assert: element skinManager isNil.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
-	self assert: element skinManager isNil.
 
+	space deferAndSettle: [ space root addChild: element ].
+	self assert: element skinManager isNil.
 ]
 
 { #category : #tests }
@@ -138,16 +127,9 @@ ToBlElementTest >> testBlElementShouldNotHaveSkinManagerEvenAsChildOfAToElement 
 	element border: Color black.
 	pane addChild: element.
 	self assert: element skinManager isNil.
-	space root addChild: pane.
-	self assert: element skinManager isNil.
-	self waitTestingSpaces.
-	self assert: element skinManager isNil.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
-	self assert: element skinManager isNil.
 
-
-
+	space deferAndSettle: [ space root addChild: pane ].
+	self assert: element skinManager isNil.
 ]
 
 { #category : #tests }
@@ -155,24 +137,18 @@ ToBlElementTest >> testElementRemovedFromSceneGraph [
 	" test that a requestUninstallSkin is sent to an element when it is removed from a space. "
 	" this ensures that the skin is removed if the element is added back as a child."
 
-	space root addChild: element.
-	self assert: element skinManager isNil.
-	space root removeChild: element.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: element ].
 	self assert: element skinManager isNil.
 
-	
-	
+	space deferAndSettle: [ space root removeChild: element ].
+	self assert: element skinManager isNil.
 ]
 
 { #category : #tests }
 ToBlElementTest >> testEnsureCanManageToploSkin [
 
 	element ensureCanManageToploSkin.
-	space root addChild: element.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: element ].
 	self assert: element skinManager installedSkin isThemeSkin 
 ]
 
@@ -221,7 +197,39 @@ ToBlElementTest >> testHasAllStamps [
 	element addAllStamps: { #color. #background }.
 	self assert: (element hasAllStamps: { #color. #background }).	
 	self deny: (element hasAllStamps: { #something. #background }).	
+]
 
+{ #category : #'tests - focus' }
+ToBlElementTest >> testHasFocusedParentWhenParentIsFocused [
+
+	| container child |
+	container := BlElement new.
+	child := BlElement new.
+	container addChild: child.
+	space deferAndSettle: [ space root addChild: container ].
+	self deny: container hasFocusedParent.
+	self deny: child hasFocusedParent.
+
+	space deferAndSettle: [ container requestFocus ].
+	self assert: container isFocused.
+	self assert: container hasFocusedParent.
+	self deny: child isFocused.
+	self assert: child hasFocusedParent
+]
+
+{ #category : #'tests - focus' }
+ToBlElementTest >> testHasFocusedParentWhenSpaceRootIsFocused [
+
+	| container child |
+	container := BlElement new.
+	child := BlElement new.
+	container addChild: child.
+	space deferAndSettle: [ space root addChild: container ].
+	self assert: space root isFocused.
+	self deny: container isFocused.
+	self deny: container hasFocusedParent.
+	self deny: child isFocused.
+	self deny: child hasFocusedParent
 ]
 
 { #category : #'tests - stamp' }
@@ -232,7 +240,6 @@ ToBlElementTest >> testHasStamp [
 	element addAllStamps: { #color. #background }.
 	self assert: (element hasStamp: #color ).	
 	self deny: (element hasStamp: #something ).	
-
 ]
 
 { #category : #'tests - token properties' }
@@ -341,8 +348,6 @@ ToBlElementTest >> testRemoveTokenPropertyNamed4 [
 	self assert: element tokenPropertyMap size equals: 1.
 	element tokenPropertyMap removePropertyNamed: #color.
 	self assert: element tokenPropertyMap isEmpty.
-
-
 ]
 
 { #category : #tests }
@@ -354,13 +359,12 @@ ToBlElementTest >> testRequestSkin [
 	element ensuredSkinManager requestNewSkinIn: element.
 	self assert: element skinManager newSkinRequested.
 	self assert: element skinManager installedSkin isUnknownSkin .
-	space root addChild: element.
-	self assert: element skinManager newSkinRequested.
-	self assert: element skinManager installedSkin isUnknownSkin.
-	space applyAllSkinInstallers.
+
+	space deferAndSettle: [
+		space root addChild: element.
+		element ensuredSkinManager requestNewSkinIn: element ].
 	self deny: element skinManager newSkinRequested.
 	self assert: element skinManager installedSkin isThemeSkin 
-	
 ]
 
 { #category : #tests }
@@ -369,16 +373,14 @@ ToBlElementTest >> testRequestSkin2 [
 	self assert: element skinManager isNil.
 	self assert: element skinManager isNil.
 	self assert: element skinManager isNil.
-	space root addChild: element.
+
+	space deferAndSettle: [ space root addChild: element ].
 	self assert: element skinManager isNil.
-	element ensuredSkinManager requestNewSkinIn: element.
+
+	space deferAndSettle: [ element ensuredSkinManager requestNewSkinIn: element ].
 	self assert: element skinManager notNil.
 	self deny: element skinManager newSkinRequested.
 	self assert: element skinManager installedSkin isThemeSkin.
-	" apply skin installer from space has no effect on e since it has no skinInstaller "
-	space applyAllSkinInstallers.
-	self deny: element skinManager newSkinRequested.
-	self assert: element skinManager installedSkin isThemeSkin
 ]
 
 { #category : #'tests - styleSheet' }
@@ -395,7 +397,6 @@ ToBlElementTest >> testSkinManager [
 	| skinManager |
 	skinManager := element skinManager.
 	self assert: skinManager isNil
-	
 ]
 
 { #category : #'tests - skin manager' }
@@ -445,7 +446,6 @@ ToBlElementTest >> testTokenPropertyMap [
 	| dict |
 	dict := element tokenPropertyMap.
 	self assert: dict isNil.
-
 ]
 
 { #category : #'tests - token properties' }
@@ -484,7 +484,7 @@ ToBlElementTest >> testTokenPropertyNamedFromBeforeSpaceShown2 [
 					 (e skinManager ifNotNil: [ :sm | sm installedSkin ]) notNil.
 				 self deny: e skinManager newSkinRequested.
 				 self assert: (e valueOfTokenNamed: #'background-color') notNil.
-				 e skinManager installNewSkinIn: e.
+				 e requestNewSkin.
 				 self deny: e background isTransparent ]).
 
 	e defaultSkin: ToBackgroundColorSkinForTest new.
@@ -505,7 +505,7 @@ ToBlElementTest >> testTokenPropertyNamedRequiresSpaceSkinPhasesStarted [
 			 on: ToSpacePhasesStarted
 			 do: [
 				 goneHere := true.
-				 e skinManager installNewSkinIn: e.
+				 e requestNewSkin.
 				 self deny: e background isTransparent ]).
 	e defaultSkin: ToBackgroundColorSkinForTest new.
 	space root addChild: e.
@@ -518,14 +518,13 @@ ToBlElementTest >> testUnsortedApplicableListenersFor [
 
 	| theme e |
 	theme := ToStyleSheetThemeForTest new.
-	space toTheme: theme.
-	space root addChild: element.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: element ].
 	self assert: (theme unsortedApplicableListenersFor: element) size equals: 0.
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (theme unsortedApplicableListenersFor: e) size equals: 5.
-
-	
 ]
 
 { #category : #'tests - stamp' }
@@ -534,9 +533,10 @@ ToBlElementTest >> testValueOfTokenNamed [
 	| theme |
 	element ensureCanManageToploSkin.
 	theme := ToRawThemeForTest new.
-	space toTheme: theme.
-	space root addTokenNamed: #testToken withValue: Color blue.
-	space root addChild: element.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addTokenNamed: #testToken withValue: Color blue.
+		space root addChild: element ].
 	self assert: (element valueOfTokenNamed: #testToken) equals: Color blue
 ]
 
@@ -546,9 +546,10 @@ ToBlElementTest >> testValueOfTokenNamed2 [
 	| theme |
 	element ensureCanManageToploSkin.
 	theme := ToRawThemeForTest new.
-	space root addTokenNamed: #testToken withValue: Color blue.
-	space toTheme: theme.
-	space root addChild: element.
+	space deferAndSettle: [
+		space root addTokenNamed: #testToken withValue: Color blue.
+		space toTheme: theme.
+		space root addChild: element ].
 	self assert: (element valueOfTokenNamed: #testToken) equals: Color blue
 ]
 
@@ -572,46 +573,9 @@ ToBlElementTest >> testValueOfTokenNamedWithNotFoundToken [
 	element addTokenNamed: #testToken withValue: Color blue.
 	self assert: (element valueOfTokenNamed: #testToken) equals: Color blue.
 	element addTokenNamed: #testToken withValue: Color yellow.
-	space root addChild: element.
+	space deferAndSettle: [ space root addChild: element ].
 	self assert: (element valueOfTokenNamed: #testToken) equals: Color yellow.
-	element removeFromParent.
+
+	space deferAndSettle: [ element removeFromParent ].
 	self assert: (element valueOfTokenNamed: #testToken) equals: Color yellow
-]
-
-{ #category : #'tests - focus' }
-ToBlElementTest >> testHasFocusedParentWhenParentIsFocused [
-
-	| container child |
-	container := BlElement new.
-	child := BlElement new.
-	container addChild: child.
-	space root addChild: container.
-	self waitTestingSpaces.
-	self deny: container hasFocusedParent.
-	self deny: child hasFocusedParent.
-
-	container requestFocus.
-	self waitTestingSpaces.
-	self assert: container isFocused.
-	self assert: container hasFocusedParent.
-	self deny: child isFocused.
-	self assert: child hasFocusedParent
-]
-
-{ #category : #'tests - focus' }
-ToBlElementTest >> testHasFocusedParentWhenSpaceRootIsFocused [
-
-	| container child |
-	container := BlElement new.
-	child := BlElement new.
-	container addChild: child.
-	space root addChild: container.
-	"Emulate the initial focus on space root that occurs when a space is shown."
-	space root requestFocus.
-	self waitTestingSpaces.
-	self assert: space root isFocused.
-	self deny: container isFocused.
-	self deny: container hasFocusedParent.
-	self deny: child isFocused.
-	self deny: child hasFocusedParent
 ]

--- a/src/Toplo-Tests/ToElementTest.class.st
+++ b/src/Toplo-Tests/ToElementTest.class.st
@@ -1,10 +1,7 @@
-"
-A ToElementTest is a test class for testing the behavior of ToElement
-"
 Class {
 	#name : #ToElementTest,
 	#superclass : #ToTestCaseWithSpace,
-	#category : #'Toplo-Tests-Core'
+	#category : #'Toplo-Tests-Core-Element'
 }
 
 { #category : #'test initialize' }
@@ -12,27 +9,27 @@ ToElementTest >> testApplySkinInstallerOnFirstRequest [
 
 	| e |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinManager installedSkin isThemeSkin.
-	space applyAllSkinInstallers.
-	self deny: e skinManager newSkinRequested.
-	self assert: e skinManager installedSkin isThemeSkin
 ]
 
 { #category : #'test initialize' }
 ToElementTest >> testApplySkinInstallerOnFirstRequestButWithNoEffect [
 
-	| e |
+	| e requested |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	" the skin installer is not immediately applied after it has been already requested. "
 	" no skin installer anymore "
 	self deny: e skinManager newSkinRequested.
 	" and to not have an installed skin -> illustrates no effect of applySkinInstallerOnFirstRequest: "
 	self assert: e skinManager installedSkin isThemeSkin.
-	e ensuredSkinManager requestNewSkinIn: e.
-	self assert: e skinManager newSkinRequested.
+
+	space deferAndSettle: [
+		e ensuredSkinManager requestNewSkinIn: e.
+		requested := e skinManager newSkinRequested ].
+	self assert: requested.
 	self assert: e skinManager installedSkin isThemeSkin
 ]
 
@@ -50,16 +47,9 @@ ToElementTest >> testDefaultSkin [
 
 	| e sk sk2 |
 	e := ToElement new.
-	space root addChild: e.
-	e defaultSkin: (sk := ToRawSkinForTest new).
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
-	self assert: e skinManager installedSkin isThemeSkin.
-	e ensuredSkinManager requestNewSkinIn: e.
-	" no change "
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
-	self assert: e skinManager installedSkin isThemeSkin.
-	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 0.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ space root addChild: e ].
+	sk := ToRawSkinForTest new.
+	space deferAndSettle: [ e defaultSkin: sk ].
 	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
 	self assert: e skinManager installedSkin identicalTo: sk.
 	self
@@ -68,25 +58,14 @@ ToElementTest >> testDefaultSkin [
 			size
 		equals: 1.
 	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0.
+	self assert: (sk receivedCountForClass: ToUninstallSkinEvent) equals: 0.
 
-	e defaultSkin: sk.
-	e ensuredSkinManager requestNewSkinIn: e.
+	space deferAndSettle: [ e defaultSkin: sk ].
 	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0.
+	self assert: (sk receivedCountForClass: ToUninstallSkinEvent) equals: 0.
 
-	self
-		assert:
-		(e eventDispatcher handlers select: [ :h | h isKindOf: ToSkin ])
-			size
-		equals: 1.
-
-	e defaultSkin: (sk2 := ToRawSkinForTest new).
-	e skinManager installNewSkinIn: e.
+	sk2 := ToRawSkinForTest new.
+	space deferAndSettle: [ e defaultSkin: sk2 ].
 
 	self
 		assert:
@@ -95,44 +74,32 @@ ToElementTest >> testDefaultSkin [
 		equals: 1.
 
 	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 1.
-	self
-		assert: (sk2 receivedCountForClass: ToInstallSkinEvent)
-		equals: 1.
-	self
-		assert: (sk2 receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0
+	self assert: (sk receivedCountForClass: ToUninstallSkinEvent) equals: 1.
+	self assert: (sk2 receivedCountForClass: ToInstallSkinEvent) equals: 1.
+	self assert: (sk2 receivedCountForClass: ToUninstallSkinEvent) equals: 0
 ]
 
 { #category : #'test initialize' }
 ToElementTest >> testInstallNewSkinNow [
 
-	| e skin |
+	| e skin skinBefore requested |
 	e := ToElementForRawSkinTest new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
-	self assert:
-		e skinManager installedSkin isThemeSkin.
-	space applyAllSkinInstallers.
-	self deny: e skinManager newSkinRequested.
-	self assert:
-		e skinManager installedSkin isThemeSkin.
-	skin := e skinManager installedSkin .
+	self assert: e skinManager installedSkin isThemeSkin.
+	skin := e skinManager installedSkin.
+	
 	" now request a skin installation "
-	e ensuredSkinManager requestNewSkinIn: e.
-	self assert: e skinManager newSkinRequested.
-	" apply all skin installers "
-	space applyAllSkinInstallers.
-	" but the installation has no effect because there is already one skin installed "
-	self
-		assert: e skinManager installedSkin isThemeSkin.
-	" now force a new skin installation "
-	self installNewSkinNowIn: e.
-	self
-		deny: e skinManager installedSkin
-		identicalTo: skin.
+	space deferAndSettle: [
+		e ensuredSkinManager requestNewSkinIn: e.
+		requested := e skinManager newSkinRequested.
+		skinBefore := e skinManager installedSkin.
+		" now force a new skin installation "
+		self installNewSkinNowIn: e ].
+	
+	self assert: requested.
+	self assert: skinBefore isThemeSkin.
+	self deny: e skinManager installedSkin identicalTo: skin.
 	self deny: e skinManager newSkinRequested
 ]
 
@@ -144,7 +111,6 @@ ToElementTest >> testInstallNewSkinNowForANonAttachedElementShouldRaiseError [
 	" now try to force a new skin installation -> error 
 	because the element is not attached "
 	self should: [ self installNewSkinNowIn: e ] raise: Error.
-
 ]
 
 { #category : #'test initialize' }
@@ -152,24 +118,24 @@ ToElementTest >> testOnAddedToParent [
 
 	| e container |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e isEnabled.
 	e := ToElement new.
 	e disable.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e isDisabled.
 	e := ToElement new.
-	space root
-		disable;
-		addChild: e.
+	space deferAndSettle: [
+		space root disable.
+		space root addChild: e ].
 	self assert: e isDisabled.
 
 	container := ToElement new.
 	e := ToElement new.
-	space root
-		disable;
-		addChild: container.
-	container addChild: e.
+	space deferAndSettle: [
+		space root disable.
+		space root addChild: container.
+		container addChild: e ].
 	self assert: e isDisabled
 ]
 
@@ -179,7 +145,8 @@ ToElementTest >> testOnAddedToSceneGraph [
 	| e |
 	e := ToElement new.
 	self deny: e skinManager newSkinRequested.
-	space root addChild: e.
+
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinManager installedSkin isThemeSkin
 ]
@@ -196,11 +163,7 @@ ToElementTest >> testRequestSkin [
 	self assert: e skinManager newSkinRequested.
 	self assert:
 		e skinManager installedSkin isUnknownSkin.
-	space root addChild: e.
-	self deny: e skinManager newSkinRequested.
-	self assert:
-		e skinManager installedSkin isThemeSkin.
-	space applyAllSkinInstallers.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert:
 		e skinManager installedSkin isThemeSkin
@@ -214,12 +177,9 @@ ToElementTest >> testRequestSkin2 [
 	self deny: e skinManager newSkinRequested.
 	self deny:
 		e skinManager installedSkin isThemeSkin.
-	space root addChild: e.
-	e ensuredSkinManager requestNewSkinIn: e.
-	self assert: e skinManager newSkinRequested.
-	self assert:
-		e skinManager installedSkin isThemeSkin.
-	space applyAllSkinInstallers.
+	space deferAndSettle: [
+		space root addChild: e .
+		e ensuredSkinManager requestNewSkinIn: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert:
 		e skinManager installedSkin isThemeSkin
@@ -231,45 +191,21 @@ ToElementTest >> testSetSkin [
 
 	| e sk sk2 |
 	e := ToElement new.
-	space root addChild: e.
-	e defaultSkin: (sk := ToRawSkinForTest new).
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
-	self assert: e skinManager installedSkin isThemeSkin.
-	e ensuredSkinManager requestNewSkinIn: e.
-	" no change "
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
-	self assert: e skinManager installedSkin isThemeSkin.
-	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 0.
-	e skinManager installNewSkinIn: e.
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
+	space deferAndSettle: [ space root addChild: e ].
+	sk := ToRawSkinForTest new.
+	space deferAndSettle: [ e skinManager setSkin: sk in: e ].
 	self assert: e skinManager installedSkin identicalTo: sk.
-	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0.
-
 	self
 		assert:
 		(e eventDispatcher handlers select: [ :h | h isKindOf: ToSkin ])
 			size
 		equals: 1.
-
-	" force uninstall->install->initial states "
-	e defaultSkin: (sk := ToRawSkinForTest new).
-	e skinManager installNewSkinIn: e.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0.
 	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
+	self assert: (sk receivedCountForClass: ToUninstallSkinEvent) equals: 0.
 
-	self
-		assert:
-		(e eventDispatcher handlers select: [ :h | h isKindOf: ToSkin ])
-			size
-		equals: 1.
-
-	e defaultSkin: (sk2 := ToRawSkinForTest new).
-	e skinManager installNewSkinIn: e.
+	" force uninstall->install "
+	sk2 := ToRawSkinForTest new.
+	space deferAndSettle: [ e skinManager setSkin: sk2 in: e ].
 
 	self
 		assert:
@@ -278,15 +214,9 @@ ToElementTest >> testSetSkin [
 		equals: 1.
 
 	self assert: (sk receivedCountForClass: ToInstallSkinEvent) equals: 1.
-	self
-		assert: (sk receivedCountForClass: ToUninstallSkinEvent)
-		equals: 1.
-	self
-		assert: (sk2 receivedCountForClass: ToInstallSkinEvent)
-		equals: 1.
-	self
-		assert: (sk2 receivedCountForClass: ToUninstallSkinEvent)
-		equals: 0
+	self assert: (sk receivedCountForClass: ToUninstallSkinEvent) equals: 1.
+	self assert: (sk2 receivedCountForClass: ToInstallSkinEvent) equals: 1.
+	self assert: (sk2 receivedCountForClass: ToUninstallSkinEvent) equals: 0
 ]
 
 { #category : #'test initialize' }
@@ -297,7 +227,8 @@ ToElementTest >> testSkinInstallRequestCount [
 	self assert: e skinManager installedSkin isUnknownSkin.
 	e ensuredSkinManager requestNewSkinIn: e.
 	self assert: e skinManager installedSkin isUnknownSkin.
-	space root addChild: e.
+
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager installedSkin isUnknownSkin
 ]
 
@@ -307,9 +238,10 @@ ToElementTest >> testWithNullSkin [
 	| e |
 	e := ToElement new.
 	e ensuredSkinManager requestNewSkinIn: e.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
-	e skinManager installNewSkinIn: e.
+
+	space deferAndSettle: [ e skinManager installNewSkinIn: e ].
 	self
 		assert:
 		(e eventDispatcher handlers select: [ :h | h isKindOf: ToSkin ])
@@ -319,7 +251,7 @@ ToElementTest >> testWithNullSkin [
 	e withNullSkin.
 	self assert: (e skinManager skinToInstallIn: e) isNullSkin.
 
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ e skinManager installNewSkinIn: e ].
 	self
 		assert:
 		(e eventDispatcher handlers select: [ :h | h isKindOf: ToSkin ])
@@ -337,29 +269,26 @@ ToElementTest >> testWithoutSkinNonContamination [
 	| e child childchild |
 	e := ToElement new.
 	e defaultSkin: ToRawSkin new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	child defaultSkin: ToRawSkin new.
 	childchild := ToElement new.
 	childchild defaultSkin: ToRawSkin new.
-	child addChild: childchild.
-	e addChild: child.
-	e ensuredSkinManager requestNewSkinIn: e.
-	e withNullSkin.
+	space deferAndSettle: [
+		child addChild: childchild.
+		e addChild: child.
+		e ensuredSkinManager requestNewSkinIn: e.
+		e withNullSkin ].
 	" withoutSkin must be applied to the element hierarchy "
 	self assert: (e skinManager skinToInstallIn: e) isNullSkin.
 	self deny: (child skinManager skinToInstallIn: child) isNullSkin.
-	self deny:
-		(childchild skinManager skinToInstallIn: childchild) isNullSkin.
-
-	e space applyAllSkinInstallers.
-
-	self deny: e skinManager newSkinRequested.
-	self assert: e skinManager installedSkin isNullSkin.
-	self deny: child skinManager newSkinRequested.
-	self assert: child skinManager installedSkin notNil.
-	self deny: childchild skinManager newSkinRequested.
-	self assert: childchild skinManager installedSkin notNil
+	self deny: (childchild skinManager skinToInstallIn: childchild) isNullSkin.
+	self deny: (e skinManager newSkinRequested).
+	self assert: (e skinManager installedSkin) isNullSkin.
+	self deny: (child skinManager newSkinRequested).
+	self assert: (child skinManager installedSkin) notNil.
+	self deny: (childchild skinManager newSkinRequested).
+	self assert: (childchild skinManager installedSkin) notNil
 ]
 
 { #category : #'test initialize' }
@@ -369,22 +298,24 @@ ToElementTest >> testWithoutSkinNonContamination2 [
 
 	| e child childchild |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	childchild := ToElement new.
-	child addChild: childchild.
-	e withNullSkin.
-	e ensuredSkinManager requestNewSkinIn: e.
+	space deferAndSettle: [
+		child addChild: childchild.
+		e withNullSkin.
+		e ensuredSkinManager requestNewSkinIn: e ].
 	self assert: (e skinManager skinToInstallIn: e) isNullSkin.
-	self assert: e skinManager installedSkin isThemeSkin.
-	self deny: childchild skinManager installedSkin isThemeSkin.
-	e skinManager installNewSkinIn: e.
-	self deny: e skinManager newSkinRequested.
-	self assert: e skinManager installedSkin isNullSkin.
-	e addChild: child.
-	e space applyAllSkinInstallers.
-	self deny: child skinManager newSkinRequested.
-	self assert: child skinManager installedSkin isThemeSkin.
-	self deny: childchild skinManager newSkinRequested.
-	self assert: childchild skinManager installedSkin isThemeSkin
+	self assert: (e skinManager installedSkin) isThemeSkin.
+	self deny: (childchild skinManager installedSkin) isThemeSkin.
+
+	space deferAndSettle: [ e skinManager installNewSkinIn: e ].
+	self deny: (e skinManager newSkinRequested).
+	self assert: (e skinManager installedSkin) isNullSkin.
+
+	space deferAndSettle: [ e addChild: child ].
+	self deny: (child skinManager newSkinRequested).
+	self assert: (child skinManager installedSkin) isThemeSkin.
+	self deny: (childchild skinManager newSkinRequested).
+	self assert: (childchild skinManager installedSkin) isThemeSkin
 ]

--- a/src/Toplo-Tests/ToElementTreeSkinUsingParentStampTest.class.st
+++ b/src/Toplo-Tests/ToElementTreeSkinUsingParentStampTest.class.st
@@ -35,7 +35,7 @@ ToElementTreeSkinUsingParentStampTest >> newElementTree [
 
 	child addChild: subChild.
 	parent addChild: child.
-	space root addChild: parent
+	space deferAndSettle: [ space root addChild: parent ]
 ]
 
 { #category : #running }
@@ -49,39 +49,33 @@ ToElementTreeSkinUsingParentStampTest >> setUp [
 ToElementTreeSkinUsingParentStampTest >> testChildSkinApplication [
 	" updating a stamp in the parent should lead to the re-installation of children skins "
 
-	parent updateStamp: #'child-color' withValue: Color white.
-	self waitTestingSpaces.
+	space deferAndSettle: [ parent updateStamp: #'child-color' withValue: Color white ].
 	self assert: child background paint color equals: Color white
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingParentStampTest >> testInitialSkinsApplication [
 
-	self waitTestingSpaces.
 	self assert: (parent background isKindOf: BlPaintBackground).
 	self assert: (child background isKindOf: BlPaintBackground).
 	self assert: (subChild background isKindOf: BlPaintBackground).
 	self assert: parent background paint color equals: Color red.
 	self assert: child background paint color equals: Color blue.
-	self assert: subChild background paint color equals: Color yellow.
-
+	self assert: subChild background paint color equals: Color yellow
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingParentStampTest >> testParentSkinApplication [
 	" updating a stamp in the parent should lead to the re-installation of the parent skin "
 
-	parent updateStamp: #'parent-color' withValue: Color brown.
-	self waitTestingSpaces.
-	self assert: parent background paint color equals: Color brown.	
-
+	space deferAndSettle: [ parent updateStamp: #'parent-color' withValue: Color brown ].
+	self assert: parent background paint color equals: Color brown
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingParentStampTest >> testSubChildSkinApplication [
 	" updating a stamp in the parent should lead to the re-installation of children skins "
 
-	parent updateStamp: #'subChild-color' withValue: Color black.
-	self waitTestingSpaces.
+	space deferAndSettle: [ parent updateStamp: #'subChild-color' withValue: Color black ].
 	self assert: subChild background paint color equals: Color black
 ]

--- a/src/Toplo-Tests/ToElementTreeSkinUsingTokenPropertiesTest.class.st
+++ b/src/Toplo-Tests/ToElementTreeSkinUsingTokenPropertiesTest.class.st
@@ -33,7 +33,7 @@ ToElementTreeSkinUsingTokenPropertiesTest >> newElementTree [
 
 	child addChild: subChild.
 	parent addChild: child.
-	space root addChild: parent
+	space deferAndSettle: [ space root addChild: parent ]
 ]
 
 { #category : #running }
@@ -47,43 +47,37 @@ ToElementTreeSkinUsingTokenPropertiesTest >> setUp [
 ToElementTreeSkinUsingTokenPropertiesTest >> testChildSkinApplication [
 	" updating a token value in the parent should lead to the re-installation of children skins "
 
-	parent updateTokenNamed: #'element-color' withValue: Color white.
-	self waitTestingSpaces.
+	space deferAndSettle: [ parent updateTokenNamed: #'element-color' withValue: Color white ].
 	self assert: child background paint color equals: Color white
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingTokenPropertiesTest >> testInitialSkinsApplication [
 
-	self waitTestingSpaces.
 	self assert: (parent background isKindOf: BlPaintBackground).
 	self assert: (child background isKindOf: BlPaintBackground).
 	self assert: (subChild background isKindOf: BlPaintBackground).
 	self assert: parent background paint color equals: Color black.
 	self assert: child background paint color equals: Color black.
-	self assert: subChild background paint color equals: Color black.
-
+	self assert: subChild background paint color equals: Color black
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingTokenPropertiesTest >> testParentSkinApplication [
 	" updating a token value in the parent should lead to the re-installation of the parent skin "
 
-	parent updateTokenNamed: #'element-color' withValue: Color white.
-	self waitTestingSpaces.
-	self assert: parent background paint color equals: Color white.	
-
+	space deferAndSettle: [ parent updateTokenNamed: #'element-color' withValue: Color white ].
+	self assert: parent background paint color equals: Color white
 ]
 
 { #category : #tests }
 ToElementTreeSkinUsingTokenPropertiesTest >> testRemovingTokenLeadsToError [
-	" updating a token value in the parent should lead to the re-installation of children skins "
+	" removing a token value in the parent should lead to lookup error "
 
 	parent removeTokenNamed: #'element-color'.
-	self should: [ self waitTestingSpaces ] raise: ToTokenPropertyNotFoundError.
-	" add the token back because #tearDown sends #waitTestingSpaces "
-	parent addTokenNamed: #'element-color' withValue: Color black.
-	self waitTestingSpaces.
+	self should: [ child valueOfTokenNamed: #'element-color' ] raise: ToTokenPropertyNotFoundError.
+	" add the token back to allow clean skin application "
+	space deferAndSettle: [ parent addTokenNamed: #'element-color' withValue: Color black ].
 	self assert: parent background paint color equals: Color black
 ]
 
@@ -91,8 +85,7 @@ ToElementTreeSkinUsingTokenPropertiesTest >> testRemovingTokenLeadsToError [
 ToElementTreeSkinUsingTokenPropertiesTest >> testSubChildSkinApplication [
 	" updating a token value in the parent should lead to the re-installation of children skins "
 
-	parent updateTokenNamed: #'element-color' withValue: Color white.
-	self waitTestingSpaces.
+	space deferAndSettle: [ parent updateTokenNamed: #'element-color' withValue: Color white ].
 	self assert: subChild background paint color equals: Color white
 ]
 
@@ -100,13 +93,13 @@ ToElementTreeSkinUsingTokenPropertiesTest >> testSubChildSkinApplication [
 ToElementTreeSkinUsingTokenPropertiesTest >> testSubChildWithLocalTokenSkinApplication [
 	" updating a token value in the parent should lead to the re-installation of children skins "
 
-	parent updateTokenNamed: #'element-color' withValue: Color white.
-	child addTokenNamed: #'element-color' withValue: Color gray.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		parent updateTokenNamed: #'element-color' withValue: Color white.
+		child addTokenNamed: #'element-color' withValue: Color gray ].
 	self assert: parent background paint color equals: Color white.
 	self assert: child background paint color equals: Color gray.
 	self assert: subChild background paint color equals: Color gray.
-	child removeTokenNamed: #'element-color'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child removeTokenNamed: #'element-color' ].
 	self assert: subChild background paint color equals: Color white
 ]

--- a/src/Toplo-Tests/ToIntrinsicStateTest.class.st
+++ b/src/Toplo-Tests/ToIntrinsicStateTest.class.st
@@ -15,8 +15,7 @@ ToIntrinsicStateTest >> testApplyEnablementOn [
 	e addEventHandler: (BlEventHandler
 			 on: ToDisabledSkinEvent
 			 do: [ :event | receivedDisabledEvt := event ]).
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (receivedEnabledEvt isKindOf: ToEnabledSkinEvent)
 ]
 
@@ -32,8 +31,7 @@ ToIntrinsicStateTest >> testApplyEnablementOn2 [
 	e addEventHandler: (BlEventHandler
 			 on: ToDisabledSkinEvent
 			 do: [ :event | receivedDisabledEvt := event ]).
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (receivedEnabledEvt isKindOf: ToEnabledSkinEvent)
 ]
 
@@ -49,8 +47,7 @@ ToIntrinsicStateTest >> testApplyEnablementOn3 [
 	e addEventHandler: (BlEventHandler
 			 on: ToDisabledSkinEvent
 			 do: [ :event | receivedDisabledEvt := event ]).
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (receivedEnabledEvt isKindOf: ToEnabledSkinEvent)
 ]
 
@@ -66,8 +63,7 @@ ToIntrinsicStateTest >> testApplyEnablementOnWhenDisabled [
 	e addEventHandler: (BlEventHandler
 			 on: ToDisabledSkinEvent
 			 do: [ :event | receivedDisabledEvt := event ]).
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (receivedDisabledEvt isKindOf: ToDisabledSkinEvent)
 ]
 
@@ -83,7 +79,7 @@ ToIntrinsicStateTest >> testApplyEnablementOnWhenDisabled2 [
 	e addEventHandler: (BlEventHandler
 			 on: ToDisabledSkinEvent
 			 do: [ :event | receivedDisabledEvt := event ]).
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: (receivedDisabledEvt isKindOf: ToDisabledSkinEvent)
 ]
 
@@ -101,7 +97,6 @@ ToIntrinsicStateTest >> testApplyOnChecked [
 
 	| e state checkedEvt uncheckedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e addEventHandler: (BlEventHandler
 			 on: ToCheckedSkinEvent
 			 do: [ :event | checkedEvt := event ]).
@@ -109,7 +104,9 @@ ToIntrinsicStateTest >> testApplyOnChecked [
 			 on: ToUncheckedSkinEvent
 			 do: [ :event | uncheckedEvt := event ]).
 	state := ToIntrinsicState new checkedSkinEvent: ToCheckedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (checkedEvt isKindOf: ToCheckedSkinEvent)
 ]
 
@@ -121,7 +118,6 @@ ToIntrinsicStateTest >> testApplyOnCheckedWhenDisabled [
 
 	| e state checkedEvt uncheckedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e disable.
 	e addEventHandler: (BlEventHandler
 			 on: ToCheckedSkinEvent
@@ -130,10 +126,13 @@ ToIntrinsicStateTest >> testApplyOnCheckedWhenDisabled [
 			 on: ToUncheckedSkinEvent
 			 do: [ :event | uncheckedEvt := event ]).
 	state := ToIntrinsicState new checkedSkinEvent: ToCheckedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (checkedEvt isKindOf: ToCheckedSkinEvent).
 	state := ToIntrinsicState new checkedSkinEvent: ToUncheckedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		state applyOn: e fromQueue: nil ].
 	self assert: (uncheckedEvt isKindOf: ToUncheckedSkinEvent)
 ]
 
@@ -142,7 +141,6 @@ ToIntrinsicStateTest >> testApplyOnFocused [
 
 	| e state focusedEvt unfocusedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e addEventHandler: (BlEventHandler
 			 on: ToFocusedSkinEvent
 			 do: [ :event | focusedEvt := event ]).
@@ -150,7 +148,9 @@ ToIntrinsicStateTest >> testApplyOnFocused [
 			 on: ToUnfocusedSkinEvent
 			 do: [ :event | unfocusedEvt := event ]).
 	state := ToIntrinsicState new focusedSkinEvent: ToFocusedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (focusedEvt isKindOf: ToFocusedSkinEvent).
 	self assert: unfocusedEvt isNil
 ]
@@ -163,7 +163,6 @@ ToIntrinsicStateTest >> testApplyOnFocusedWhenDisabled [
 
 	| e state focusedEvt unfocusedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e disable.
 	e addEventHandler: (BlEventHandler
 			 on: ToFocusedSkinEvent
@@ -172,10 +171,13 @@ ToIntrinsicStateTest >> testApplyOnFocusedWhenDisabled [
 			 on: ToUnfocusedSkinEvent
 			 do: [ :event | unfocusedEvt := event ]).
 	state := ToIntrinsicState new focusedSkinEvent: ToFocusedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (focusedEvt isKindOf: ToFocusedSkinEvent).
 	state := ToIntrinsicState new focusedSkinEvent: ToUnfocusedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		state applyOn: e fromQueue: nil ].
 	self assert: (unfocusedEvt isKindOf: ToUnfocusedSkinEvent)
 ]
 
@@ -184,7 +186,6 @@ ToIntrinsicStateTest >> testApplyOnUnchecked [
 
 	| e state checkedEvt uncheckedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e addEventHandler: (BlEventHandler
 			 on: ToCheckedSkinEvent
 			 do: [ :event | checkedEvt := event ]).
@@ -192,7 +193,9 @@ ToIntrinsicStateTest >> testApplyOnUnchecked [
 			 on: ToUncheckedSkinEvent
 			 do: [ :event | uncheckedEvt := event ]).
 	state := ToIntrinsicState new checkedSkinEvent: ToUncheckedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (uncheckedEvt isKindOf: ToUncheckedSkinEvent)
 ]
 
@@ -201,7 +204,6 @@ ToIntrinsicStateTest >> testApplyOnUnfocused [
 
 	| e state focusedEvt unfocusedEvt |
 	e := ToElement new.
-	space root addChild: e.
 	e addEventHandler: (BlEventHandler
 			 on: ToFocusedSkinEvent
 			 do: [ :event | focusedEvt := event ]).
@@ -209,29 +211,11 @@ ToIntrinsicStateTest >> testApplyOnUnfocused [
 			 on: ToUnfocusedSkinEvent
 			 do: [ :event | unfocusedEvt := event ]).
 	state := ToIntrinsicState new focusedSkinEvent: ToUnfocusedSkinEvent new.
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [
+		space root addChild: e.
+		state applyOn: e fromQueue: nil ].
 	self assert: (unfocusedEvt isKindOf: ToUnfocusedSkinEvent).
 	self assert: focusedEvt isNil
-]
-
-{ #category : #running }
-ToIntrinsicStateTest >> testApplyOnFocusedWhenChildOfSpaceRoot [
-
-	| e state focusedEvt |
-	e := ToElement new.
-	space root addChild: e.
-	"Emulate the initial focus on space root that occurs when a space is shown."
-	space root requestFocus.
-	state := ToIntrinsicState new.
-	"Initial application when added to space root (unfocused)"
-	state applyOn: e fromQueue: nil.
-
-	focusedEvt := nil.
-	e addEventHandlerOn: ToFocusedSkinEvent do: [ :event | focusedEvt := event ].
-	state focusedSkinEvent: ToFocusedSkinEvent new.
-	e requestFocus.
-	state applyOn: e fromQueue: nil.
-	self assert: (focusedEvt isKindOf: ToFocusedSkinEvent)
 ]
 
 { #category : #running }
@@ -242,14 +226,12 @@ ToIntrinsicStateTest >> testFocusStateWhenSpaceRootIsFocused [
 	child := ToElement new.
 	container addChild: child.
 	state := ToIntrinsicState new.
-	space root addChild: container.
-	"Emulate the initial focus on space root that occurs when a space is shown."
-	space root requestFocus.
+	space deferAndSettle: [ space root addChild: container ].
 	self assert: space root isFocused.
 	self deny: (state focusStateOn: container).
 	self deny: (state focusStateOn: child).
 
-	container requestFocus.
+	space deferAndSettle: [ container requestFocus ].
 	self assert: container isFocused.
 	self assert: (state focusStateOn: container).
 	self assert: (state focusStateOn: child)

--- a/src/Toplo-Tests/ToLabeledIconEventHandlerTest.class.st
+++ b/src/Toplo-Tests/ToLabeledIconEventHandlerTest.class.st
@@ -10,160 +10,292 @@ Class {
 { #category : #'layout constraints' }
 ToLabeledIconEventHandlerTest >> testDirection [
 
-	| li |
+	| li newSkinRequested |
 	li := ToLabeledIcon new.
-	space root addChild: li.
+	space deferAndSettle: [ space root addChild: li ].
 
-	li beStartToEnd .
-	li skinManager forceNewSkinRequested: false in: li.
-	li direction: BlLayoutDirection rightToLeft.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li direction: BlLayoutDirection rightToLeft.
-	self deny: li skinManager newSkinRequested.
+	space deferAndSettle: [
+		li beStartToEnd.
+		li skinManager forceNewSkinRequested: false in: li.
+		li direction: BlLayoutDirection rightToLeft.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
 
-	li skinManager forceNewSkinRequested: false in: li.
-	li direction: BlLayoutDirection leftToRight.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li direction: BlLayoutDirection leftToRight.
-	self deny: li skinManager newSkinRequested.
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li direction: BlLayoutDirection rightToLeft.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
 
-	li direction: BlLayoutDirection rightToLeft.
-	self assert: li skinManager newSkinRequested
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li direction: BlLayoutDirection leftToRight.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li direction: BlLayoutDirection leftToRight.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li direction: BlLayoutDirection rightToLeft.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested
 ]
 
 { #category : #'layout constraints' }
 ToLabeledIconEventHandlerTest >> testLayoutDirectionChangedEvent [
 
-	| li |
+	| li newSkinRequested |
 	li := ToLabeledIcon new.
-	space root addChild: li.
-	li beStartToEnd.
-	li beEndToStart.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li beStartToEnd.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li startToEnd: false.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li startToEnd: true.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li endToStart: true.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li endToStart: false.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
+	space deferAndSettle: [ space root addChild: li ].
+	
+	space deferAndSettle: [
+		li beStartToEnd.
+		li beEndToStart.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
 
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li beStartToEnd.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li startToEnd: false.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li startToEnd: true.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li endToStart: true.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li endToStart: false.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li ]
 ]
 
 { #category : #'layout constraints' }
 ToLabeledIconEventHandlerTest >> testLayoutOrientationChangedEvent [
 
-	| li |
+	| li newSkinRequested |
 	li := ToLabeledIcon new.
-	space root addChild: li.
-	li beHorizontal.
-	li beVertical.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li beHorizontal.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li vertical: true.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li vertical: false.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li horizontal: false.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li horizontal: true.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
+	space deferAndSettle: [ space root addChild: li ].
 
+	space deferAndSettle: [
+		li beHorizontal.
+		li beVertical.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li beHorizontal.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li vertical: true.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li vertical: false.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li horizontal: false.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li horizontal: true.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li ]
 ]
 
 { #category : #'layout constraints' }
 ToLabeledIconEventHandlerTest >> testOrientation [
 
-	| li |
+	| li newSkinRequested |
 	li := ToLabeledIcon new.
-	space root addChild: li.
-	li beStartToEnd.
-	li skinManager forceNewSkinRequested: false in: li.
-	li orientation: BlLinearLayoutOrientation vertical.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li orientation: BlLinearLayoutOrientation vertical.
-	self deny: li skinManager newSkinRequested.
+	space deferAndSettle: [ space root addChild: li ].
 
-	li skinManager forceNewSkinRequested: false in: li.
-	li orientation: BlLinearLayoutOrientation horizontal.
-	self assert: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	li orientation: BlLinearLayoutOrientation horizontal.
-	self deny: li skinManager newSkinRequested
+	space deferAndSettle: [
+		li beStartToEnd.
+		li skinManager forceNewSkinRequested: false in: li.
+		li orientation: BlLinearLayoutOrientation vertical.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li orientation: BlLinearLayoutOrientation vertical.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li orientation: BlLinearLayoutOrientation horizontal.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self assert: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		li orientation: BlLinearLayoutOrientation horizontal.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested
 ]
 
 { #category : #'layout constraints' }
 ToLabeledIconEventHandlerTest >> testlayoutConstraintsChangedEvent [
 
-	| li |
+	| li newSkinRequested |
 	li := ToLabeledIcon new.
-	space root addChild: li.
-	li exact: 10 @ 10.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li fitContent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li fitContentLimited.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li hExact: 20.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li hFitContent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li hFitContentLimited.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li hMatchParent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li matchParent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li vExact: 20.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li vFitContent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li vFitContentLimited.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
-	li vMatchParent.
-	self deny: li skinManager newSkinRequested.
-	li skinManager forceNewSkinRequested: false in: li.
-	self deny: li skinManager newSkinRequested.
+	space deferAndSettle: [ space root addChild: li ].
 
+	space deferAndSettle: [
+		li exact: 10 @ 10.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li fitContent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li fitContentLimited.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li hExact: 20.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li hFitContent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li hFitContentLimited.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li hMatchParent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li matchParent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li vExact: 20.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li vFitContent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li vFitContentLimited.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li vMatchParent.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested.
+
+	space deferAndSettle: [
+		li skinManager forceNewSkinRequested: false in: li.
+		newSkinRequested := li skinManager newSkinRequested ].
+	self deny: newSkinRequested
 ]

--- a/src/Toplo-Tests/ToLabeledIconTest.class.st
+++ b/src/Toplo-Tests/ToLabeledIconTest.class.st
@@ -3,7 +3,7 @@ A ToLabeledIconTest is a test class for testing the behavior of ToLabeledIcon
 "
 Class {
 	#name : #ToLabeledIconTest,
-	#superclass : #TestCase,
+	#superclass : #ToParameterizedHostTest,
 	#category : #'Toplo-Tests-Core'
 }
 
@@ -19,12 +19,15 @@ ToLabeledIconTest >> testBeIconFirst [
 
 	| li |
 	li := self testInitialize.
-	li iconImage: (BlElement new
-			 extent: 60 @ 20;
-			 background: (Color blue alpha: 0.2);
-			 yourself).
-	li beStartToEnd.
-	li applyConfiguration.
+
+	space deferAndSettle: [
+		li iconImage:
+			(BlElement new
+				 extent: 60 @ 20;
+				 background: (Color blue alpha: 0.2);
+				 yourself).
+		li beStartToEnd ].
+
 	self assert: li isStartToEnd
 ]
 
@@ -33,11 +36,15 @@ ToLabeledIconTest >> testBeLabelFirst [
 
 	| li |
 	li := self testInitialize.
-	li iconImage: (BlElement new
-			 extent: 60 @ 20;
-			 background: (Color blue alpha: 0.2);
-			 yourself).
-	li beEndToStart.
+
+	space deferAndSettle: [
+		li iconImage:
+			(BlElement new
+				 extent: 60 @ 20;
+				 background: (Color blue alpha: 0.2);
+				 yourself).
+		li beEndToStart ].
+
 	self assert: li isEndToStart
 ]
 
@@ -46,12 +53,13 @@ ToLabeledIconTest >> testFiller [
 
 	| li |
 	li := self testInitialize.
+
 	self assert: li startFiller isNil.
-	li startFlexible: false.
-	li applyConfiguration.
+
+	space deferAndSettle: [ li startFlexible: false ].
 	self assert: li startFiller isNil.
-	li startFlexible: true.
-	li applyConfiguration.
+
+	space deferAndSettle: [ li startFlexible: true ].
 	self assert: li startFiller notNil
 ]
 
@@ -60,11 +68,17 @@ ToLabeledIconTest >> testHasIcon [
 
 	| li |
 	li := self testInitialize.
+
 	self deny: li hasIcon.
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
+
+	space deferAndSettle: [
+		li icon:
+			(ToImage inner:
+				(BlElement new
+					extent: 60 @ 20;
+					background: (Color blue alpha: 0.2);
+					yourself)) ].
+
 	self assert: li hasIcon
 ]
 
@@ -73,10 +87,12 @@ ToLabeledIconTest >> testHasLabel [
 
 	| li |
 	li := self testInitialize.
-	self deny: li hasLabel.
-	li label: (ToLabel text: 'A').
-	self assert: li hasLabel.
 
+	self deny: li hasLabel.
+
+	space deferAndSettle: [ li label: (ToLabel text: 'A') ].
+
+	self assert: li hasLabel
 ]
 
 { #category : #tests }
@@ -84,20 +100,21 @@ ToLabeledIconTest >> testIcon [
 
 	| li |
 	li := self testInitialize.
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li forceLayout.
-	li applyConfiguration.
+
+	space deferAndSettle: [
+		li icon:
+			(ToImage inner:
+				(BlElement new
+					extent: 60 @ 20;
+					background: (Color blue alpha: 0.2);
+					yourself)) ].
 	self assert: li width equals: li iconContainer width.
 	self assert: li height equals: li iconContainer height.
 	self assert: li hasIcon.
-	li icon: nil.
-	self assert: li icon isNil.
-	self deny: li hasIcon.
 
-	^ li
+	space deferAndSettle: [ li icon: nil ].
+	self assert: li icon isNil.
+	self deny: li hasIcon
 ]
 
 { #category : #tests }
@@ -105,17 +122,19 @@ ToLabeledIconTest >> testIconContainer [
 
 	| li |
 	li := self testInitialize.
+
 	self assert: li iconContainer isNil.
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li forceLayout.
-	li applyConfiguration.
+
+	space deferAndSettle: [
+		li icon:
+			(ToImage inner:
+				(BlElement new
+					extent: 60 @ 20;
+					background: (Color blue alpha: 0.2);
+					yourself)) ].
 	self assert: li startContainer notNil.
 	self assert: li width equals: li iconContainer width.
-	self assert: li height equals: li iconContainer height.
-	^ li
+	self assert: li height equals: li iconContainer height
 ]
 
 { #category : #tests }
@@ -123,8 +142,8 @@ ToLabeledIconTest >> testIconContainerHeight [
 
 	| li |
 	li := self testWithLabelAndIcon.
-	li iconContainer height: 40.
-	li forceLayout.
+
+	space deferAndSettle: [ li iconContainer height: 40 ].
 	self
 		assert: li height
 		equals: (li labelContainer height max: li iconContainer height)
@@ -135,9 +154,10 @@ ToLabeledIconTest >> testIconContainerHeightVertical [
 
 	| li |
 	li := self testWithLabelAndIcon.
-	li beVertical.
-	li iconContainer height: 40.
-	li forceLayout.
+
+	space deferAndSettle: [
+		li beVertical.
+		li iconContainer height: 40 ].
 	self
 		assert: li height
 		equals: li labelContainer height + li iconContainer height.
@@ -151,8 +171,8 @@ ToLabeledIconTest >> testIconContainerWidth [
 
 	| li |
 	li := self testWithLabelAndIcon.
-	li iconContainer width: 40.
-	li forceLayout.
+
+	space deferAndSettle: [ li iconContainer width: 40 ].
 	self
 		assert: li width
 		equals: li labelContainer width + li iconContainer width.
@@ -166,9 +186,10 @@ ToLabeledIconTest >> testIconContainerWidthVertical [
 
 	| li |
 	li := self testWithLabelAndIcon.
-	li beVertical.
-	li iconContainer width: 40.
-	li forceLayout.
+	
+	space deferAndSettle: [
+		li beVertical.
+		li iconContainer width: 40 ].
 	self
 		assert: li width
 		equals: (li labelContainer width max: li iconContainer width).
@@ -182,15 +203,15 @@ ToLabeledIconTest >> testIconImage [
 
 	| li |
 	li := self testInitialize.
-	li iconImage: (BlElement new
-			 extent: 60 @ 20;
-			 background: (Color blue alpha: 0.2);
-			 yourself).
-	li applyConfiguration.
-	li forceLayout.
+
+	space deferAndSettle: [
+		li iconImage:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself) ].
 	self assert: li width equals: li iconContainer width.
-	self assert: li height equals: li iconContainer height.
-	^ li
+	self assert: li height equals: li iconContainer height
 ]
 
 { #category : #tests }
@@ -198,11 +219,9 @@ ToLabeledIconTest >> testInitialize [
 
 	| li |
 	li := ToLabeledIcon new.
+	space deferAndSettle: [ space root addChild: li ].
 	self assert: li isStartToEnd.
 	self assert: li isHorizontal.
-	li applyConfiguration.
-	li forceLayout.
-
 	self assert: li extent equals: 0 asPoint.
 	^ li
 ]
@@ -213,15 +232,15 @@ ToLabeledIconTest >> testInterspace [
 	| li |
 	li := ToLabeledIcon new.
 	li startInterspace: 10.
-	li applyConfiguration.
-	li forceLayout.
+	space deferAndSettle: [ space root addChild: li ].
+
 	self assert: li extent equals: 10 @ 0.
-	li vFitContent.
-	li forceLayout.
+
+	space deferAndSettle: [ li vFitContent ].
 	self assert: li width equals: 10.
 	self assert: li height equals: 0.
-	li label: (ToLabel text: 'X').
-	li forceLayout.
+
+	space deferAndSettle: [ li label: (ToLabel text: 'X') ].
 	self assert: li height equals: li label height.
 	self assert: li width equals: li label width + 10
 ]
@@ -237,8 +256,7 @@ ToLabeledIconTest >> testInterspaceWithLabel [
 				  extent: 60 @ 20;
 				  background: (Color blue alpha: 0.2);
 				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	space deferAndSettle: [ space root addChild: li ].
 	self
 		assert: li labelContainer bounds left
 		equals: li iconContainer bounds right + 10
@@ -251,14 +269,12 @@ ToLabeledIconTest >> testInterspaceWithLabelAndVertical [
 	li := ToLabeledIcon new.
 	li vertical: true.
 	li startInterspace: 10.
-
 	li label: (ToLabel text: 'A').
 	li icon: (ToImage inner: (BlElement new
 				  extent: 60 @ 20;
 				  background: (Color blue alpha: 0.2);
 				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	space deferAndSettle: [ space root addChild: li ].
 	self
 		assert: li labelContainer bounds top
 		equals: li iconContainer bounds bottom + 10
@@ -269,9 +285,10 @@ ToLabeledIconTest >> testIsExact [
 
 	| li |
 	li := self testInitialize.
-	li extent: 10 @ 10.
+	space deferAndSettle: [ li extent: 10 @ 10 ].
 	self assert: li isExact.
-	li hMatchParent.
+
+	space deferAndSettle: [ li hMatchParent ].
 	self deny: li isExact
 ]
 
@@ -280,7 +297,8 @@ ToLabeledIconTest >> testIsIconFirst [
 
 	| li |
 	li := self testInitialize.
-	li beStartToEnd.
+
+	space deferAndSettle: [ li beStartToEnd ].
 	self assert: li isStartToEnd.
 	self deny: li isEndToStart.
 
@@ -291,7 +309,8 @@ ToLabeledIconTest >> testIsLabelFirst [
 
 	| li |
 	li := self testInitialize.
-	li beEndToStart.
+
+	space deferAndSettle: [ li beEndToStart ].
 	self assert: li isEndToStart.
 	self deny: li isStartToEnd.
 
@@ -303,8 +322,10 @@ ToLabeledIconTest >> testIsStartFlexible [
 
 	| li |
 	li := self testInitialize.
+
 	self deny: li isStartFlexible.
-	li startFlexible: true.
+
+	space deferAndSettle: [ li startFlexible: true ].
 	self assert: li isStartFlexible
 ]
 
@@ -313,11 +334,12 @@ ToLabeledIconTest >> testLabel [
 
 	| li |
 	li := self testInitialize.
-	li label: (ToLabel text: 'A').
-	li forceLayout.
+
+	space deferAndSettle: [ li label: (ToLabel text: 'A') ].
 	self assert: li extent equals: li labelContainer extent.
 	self assert: li hasLabel.
-	li label: nil.
+
+	space deferAndSettle: [ li label: nil ].
 	self assert: li label isNil.
 	self deny: li hasLabel.
 
@@ -329,12 +351,12 @@ ToLabeledIconTest >> testLabelContainer [
 
 	| li |
 	li := self testInitialize.
+
 	self assert: li labelContainer hasChildren not.
 	self assert: li labelContainer extent equals: 0 asPoint.
-	li label: (ToLabel text: 'A').
-	li forceLayout.
-	self assert: li extent equals: li labelContainer extent.
-	^ li
+
+	space deferAndSettle: [ li label: (ToLabel text: 'A') ].
+	self assert: li extent equals: li labelContainer extent
 ]
 
 { #category : #tests }
@@ -342,19 +364,18 @@ ToLabeledIconTest >> testLabelFirst [
 
 	| li |
 	li := self testInitialize.
-	li iconImage: (BlElement new
-			 extent: 60 @ 20;
-			 background: (Color blue alpha: 0.2);
-			 yourself).
-	li labelText: 'X'.
-	li endToStart: true.
-	li forceLayout.
-	li applyConfiguration.
 
+	space deferAndSettle: [
+		li iconImage:
+			(BlElement new
+				 extent: 60 @ 20;
+				 background: (Color blue alpha: 0.2);
+				 yourself).
+		li labelText: 'X'.
+		li endToStart: true ].
 	self
 		assert: (li label bounds inParent: li) right
-		equals: (li icon bounds inParent: li) left.
-	^ li
+		equals: (li icon bounds inParent: li) left
 ]
 
 { #category : #tests }
@@ -362,21 +383,20 @@ ToLabeledIconTest >> testLabelText [
 
 	| li |
 	li := self testInitialize.
-	li labelText: 'A' asRopedText.
-	li forceLayout.
+
+	space deferAndSettle: [ li labelText: 'A' asRopedText ].
 	self assert: li label text asString equals: 'A'.
 	self assert: li extent equals: li labelContainer extent.
 	self assert: li labelText equals: 'A'.
-	li labelText: 'X'.
-	li forceLayout.
+
+	space deferAndSettle: [ li labelText: 'X' ].
 	self assert: li label text asString equals: 'X'.
 	self assert: li extent equals: li labelContainer extent.
 	self assert: li labelText equals: 'X'.
-	li label: nil.
-	li forceLayout.
+
+	space deferAndSettle: [ li label: nil ].
 	self deny: li hasLabel.
-	self assert: li extent equals: 0 asPoint.
-	^ li
+	self assert: li extent equals: 0 asPoint
 ]
 
 { #category : #tests }
@@ -384,28 +404,26 @@ ToLabeledIconTest >> testStartAlignment [
 
 	| li |
 	li := self testInitialize.
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li label: (ToLabel text: 'ba').
-	li forceLayout.
-	li applyConfiguration.
+
+	space deferAndSettle: [
+		li icon:
+			(ToImage inner:
+				(BlElement new
+					extent: 60 @ 20;
+					background: (Color blue alpha: 0.2);
+					yourself)).
+		li label: (ToLabel text: 'ba') ].
 	self
 		assert: li labelContainer bounds left
 		equals: li iconContainer bounds right.
-	li startAlignment: 100.
-	li applyConfiguration.
-	li forceLayout.
+
+	space deferAndSettle: [ li startAlignment: 100 ].
 	self assert: li iconContainer bounds width equals: 100.
 	self assert: li labelContainer bounds left equals: 100.
-	li startAlignment: 50.
-	li applyConfiguration.
-	li forceLayout.
-	self assert: li labelContainer bounds left equals: 50.
-	self assert: li iconContainer bounds width equals: 50.
 
-	^ li
+	space deferAndSettle: [ li startAlignment: 50 ].
+	self assert: li labelContainer bounds left equals: 50.
+	self assert: li iconContainer bounds width equals: 50
 ]
 
 { #category : #tests }
@@ -413,10 +431,10 @@ ToLabeledIconTest >> testStartFlexible [
 
 	| li |
 	li := self testInitialize.
+
 	self assert: li startFiller isNil.
-	li startFlexible: true.
-	li forceLayout.
-	li applyConfiguration.
+
+	space deferAndSettle: [ li startFlexible: true ].
 	self assert: li startFiller notNil.
 	self assert: li isStartFlexible
 ]
@@ -425,20 +443,21 @@ ToLabeledIconTest >> testStartFlexible [
 ToLabeledIconTest >> testStartFlexibleInEmpty [
 
 	| li container |
-	container := ToElement new extent: 200 asPoint.
+	container := ToElement new extent: 200 asPoint; yourself.
+
 	li := ToLabeledIcon new.
 	li startFlexible: true.
 	self assert: li isStartFlexible.
 	li matchParent.
 	container addChild: li.
-	li forceLayout.
+	space deferAndSettle: [ space root addChild: container ].
 	self assert: li extent equals: 200 asPoint.
-	li vFitContent.
-	li forceLayout.
+
+	space deferAndSettle: [ li vFitContent ].
 	self assert: li width equals: 200.
 	self assert: li height equals: 0.
-	li label: (ToLabel text: 'X').
-	li forceLayout.
+
+	space deferAndSettle: [ li label: (ToLabel text: 'X') ].
 	self assert: li height equals: li label height
 ]
 
@@ -446,19 +465,20 @@ ToLabeledIconTest >> testStartFlexibleInEmpty [
 ToLabeledIconTest >> testStartFlexibleWithLabel [
 
 	| li container |
-	container := ToElement new extent: 200 asPoint.
+	container := ToElement new extent: 200 asPoint; yourself.
 	li := ToLabeledIcon new.
 	li matchParent.
 	container addChild: li.
 	li startFlexible: true.
 	li vertical: false.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	container forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: container ].
 	self assert: li labelContainer bounds right closeTo: container width.
 	self assert: li iconContainer bounds left closeTo: 0
 ]
@@ -474,12 +494,13 @@ ToLabeledIconTest >> testStartFlexibleWithLabelAndVertical [
 	container addChild: li.
 	li startFlexible: true.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	container forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: container ].
 	self assert: li labelContainer bounds bottom equals: container height.
 	self assert: li iconContainer bounds top equals: 0
 ]
@@ -489,18 +510,18 @@ ToLabeledIconTest >> testStartToEnd [
 
 	| li |
 	li := self testInitialize.
-	li iconImage: (BlElement new
-			 extent: 60 @ 20;
-			 background: (Color blue alpha: 0.2);
-			 yourself).
-	li labelText: 'X'.
-	li startToEnd: true.
-	li applyConfiguration.
-	li forceLayout.
+
+	space deferAndSettle: [
+		li iconImage:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself).
+		li labelText: 'X'.
+		li startToEnd: true ].
 	self
 		assert: (li icon bounds inParent: li) right
-		equals: (li label bounds inParent: li) left.
-	^ li
+		equals: (li label bounds inParent: li) left
 ]
 
 { #category : #tests }
@@ -508,12 +529,14 @@ ToLabeledIconTest >> testWithLabelAndIcon [
 
 	| li |
 	li := self testLabel.
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li forceLayout.
-	li applyConfiguration.
+
+	space deferAndSettle: [
+		li icon:
+			(ToImage inner:
+				(BlElement new
+					extent: 60 @ 20;
+					background: (Color blue alpha: 0.2);
+					yourself)) ].
 	self
 		assert: li width
 		equals: li labelContainer width + li iconContainer width.
@@ -531,13 +554,13 @@ ToLabeledIconTest >> testWithLabelAndIconIconFirst [
 	li endToStart: true.
 	li endToStart: false.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
-
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: li ].
 	self assert: li iconContainer bounds left equals: 0.
 	self
 		assert: li labelContainer bounds left
@@ -553,12 +576,13 @@ ToLabeledIconTest >> testWithLabelAndIconIconFirstVertical [
 	li endToStart: false.
 	li vertical: true.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: li ].
 	self assert: li iconContainer bounds top equals: 0.
 	self
 		assert: li labelContainer bounds top
@@ -572,12 +596,13 @@ ToLabeledIconTest >> testWithLabelAndIconLabelFirst [
 	li := ToLabeledIcon new.
 	li endToStart: true.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: li ].
 	self assert: li labelContainer bounds left equals: 0.
 	self
 		assert: li iconContainer bounds left
@@ -592,12 +617,13 @@ ToLabeledIconTest >> testWithLabelAndIconLabelFirstVertical [
 	li endToStart: true.
 	li vertical: true.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: li ].
 	self assert: li labelContainer bounds top equals: 0.
 	self
 		assert: li iconContainer bounds top
@@ -611,12 +637,13 @@ ToLabeledIconTest >> testWithLabelAndIconVertical [
 	li := ToLabeledIcon new.
 	li vertical: true.
 	li label: (ToLabel text: 'A').
-	li icon: (ToImage inner: (BlElement new
-				  extent: 60 @ 20;
-				  background: (Color blue alpha: 0.2);
-				  yourself)).
-	li applyConfiguration.
-	li forceLayout.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	space deferAndSettle: [ space root addChild: li ].
 	self
 		assert: li height
 		equals: li labelContainer height + li iconContainer height.

--- a/src/Toplo-Tests/ToObservableCollectionFilterApplierTest.class.st
+++ b/src/Toplo-Tests/ToObservableCollectionFilterApplierTest.class.st
@@ -80,6 +80,7 @@ ToObservableCollectionFilterApplierTest >> testNotifySelectedIndexesInEmptyColle
 { #category : #tests }
 ToObservableCollectionFilterApplierTest >> testOnInstalledIn [ 
 
+	Processor yield.
 	self assert: filter semaphore notNil.
 	self assert: filter process notNil.
 	self assert: filter process isWaiting.

--- a/src/Toplo-Tests/ToOutsideEventFilterTest.class.st
+++ b/src/Toplo-Tests/ToOutsideEventFilterTest.class.st
@@ -30,10 +30,11 @@ ToOutsideEventFilterTest >> addPane [
 		           yourself.
 	outsidePane matchParent.
 
-	filter pushElement: pane.
+	space deferAndSettle: [
+		filter pushElement: pane.
 
-	main addChild: pane.
-	main addChild: outsidePane
+		main addChild: pane.
+		main addChild: outsidePane ]
 ]
 
 { #category : #running }
@@ -65,12 +66,13 @@ ToOutsideEventFilterTest >> addPaneAndSubPane [
 		           yourself.
 	outsidePane matchParent.
 
-	filter pushElement: pane.
-	filter pushElement: subPane.
+	space deferAndSettle: [
+		filter pushElement: pane.
+		filter pushElement: subPane.
 
-	main addChild: pane.
-	main addChild: subPane.
-	main addChild: outsidePane
+		main addChild: pane.
+		main addChild: subPane.
+		main addChild: outsidePane ]
 ]
 
 { #category : #running }
@@ -80,13 +82,13 @@ ToOutsideEventFilterTest >> setUp [
 
 	main := ToPane horizontal.
 	main matchParent.
-	space root addChild: main.
+	space deferAndSettle: [ space root addChild: main ].
 
-	filter := ToOutsideEventFilter new
-		          eventsToHandle: { BlMouseUpEvent };
-		          yourself.
-	space root addEventFilter: filter.
-
+	filter :=
+		ToOutsideEventFilter new
+			eventsToHandle: { BlMouseUpEvent };
+			yourself.
+	space deferAndSettle: [ space root addEventFilter: filter ]
 ]
 
 { #category : #running }
@@ -99,10 +101,10 @@ ToOutsideEventFilterTest >> testOutsideEventWithOnePane [
 
 	pane addEventHandlerOn: ToMouseUpOutsideEvent do: [ :event | outsideEvent := event ].
 
-	BlSpace simulateClickOn: pane.
+	pane eventSimulator click.
 	self assert: outsideEvent isNil.
 	
-	BlSpace simulateClickOn: outsidePane.
+	outsidePane eventSimulator click.
 	self assert: outsideEvent notNil.
 	self assert: outsideEvent currentTarget equals: pane.
 	self assert: outsideEvent sourceEvent currentTarget equals: space root.
@@ -118,17 +120,15 @@ ToOutsideEventFilterTest >> testWithOnePane [
 	pane := main childWithId: #pane.
 	outsidePane := main childWithId: #outsidePane.
 
-	BlSpace simulateClickOn: pane.
+	pane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	
-	BlSpace simulateClickOn: outsidePane.
+	outsidePane eventSimulator click.
 	self deny: pane isAttachedToSceneGraph.
 
 	self assert: (space root eventDispatcher filters includes: filter).
-	BlSpace simulateClickOn: outsidePane.
-	self deny: (space root eventDispatcher filters includes: filter).
-	
-
+	outsidePane eventSimulator click.
+	self deny: (space root eventDispatcher filters includes: filter)
 ]
 
 { #category : #running }
@@ -141,27 +141,25 @@ ToOutsideEventFilterTest >> testWithPaneAndSubPaneCheckAll [
 	subPane := main childWithId: #subPane.
 	outsidePane := main childWithId: #outsidePane.
 
-	BlSpace simulateClickOn: pane.
+	pane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self assert: subPane isAttachedToSceneGraph.
 
-	BlSpace simulateClickOn: subPane.
+	subPane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self assert: subPane isAttachedToSceneGraph.
 	
-	BlSpace simulateClickOn: outsidePane.
+	outsidePane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 
-	BlSpace simulateClickOn: outsidePane.
+	outsidePane eventSimulator click.
 	self deny: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 
 	self assert: (space root eventDispatcher filters includes: filter).
-	BlSpace simulateClickOn: outsidePane.
-	self deny: (space root eventDispatcher filters includes: filter).
-	
-
+	outsidePane eventSimulator click.
+	self deny: (space root eventDispatcher filters includes: filter)
 ]
 
 { #category : #running }
@@ -174,27 +172,25 @@ ToOutsideEventFilterTest >> testWithPaneAndSubPaneCheckAllClickingOnSpaceRoot [
 	subPane := main childWithId: #subPane.
 	outsidePane := main childWithId: #outsidePane.
 
-	BlSpace simulateClickOn: pane.
+	pane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self assert: subPane isAttachedToSceneGraph.
 
-	BlSpace simulateClickOn: subPane.
+	subPane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self assert: subPane isAttachedToSceneGraph.
 	
-	BlSpace simulateClickOn: space root.
+	space root eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 
-	BlSpace simulateClickOn: space root.
+	space root eventSimulator click.
 	self deny: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 
 	self assert: (space root eventDispatcher filters includes: filter).
-	BlSpace simulateClickOn: space root.
-	self deny: (space root eventDispatcher filters includes: filter).
-	
-
+	space root eventSimulator click.
+	self deny: (space root eventDispatcher filters includes: filter)
 ]
 
 { #category : #running }
@@ -206,21 +202,15 @@ ToOutsideEventFilterTest >> testWithPaneAndSubPaneCheckTopOnly [
 	subPane := main childWithId: #subPane.
 	outsidePane := main childWithId: #outsidePane.
 
-	BlSpace simulateClickOn: pane.
-	self assert: pane isAttachedToSceneGraph.
-	self deny: subPane isAttachedToSceneGraph.
-
-	BlSpace simulateClickOn: subPane.
+	pane eventSimulator click.
 	self assert: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 	
-	BlSpace simulateClickOn: outsidePane.
+	outsidePane eventSimulator click.
 	self deny: pane isAttachedToSceneGraph.
 	self deny: subPane isAttachedToSceneGraph.
 
 	self assert: (space root eventDispatcher filters includes: filter).
-	BlSpace simulateClickOn: outsidePane.
-	self deny: (space root eventDispatcher filters includes: filter).
-	
-
+	outsidePane eventSimulator click.
+	self deny: (space root eventDispatcher filters includes: filter)
 ]

--- a/src/Toplo-Tests/ToOverlayWindowManagerTest.class.st
+++ b/src/Toplo-Tests/ToOverlayWindowManagerTest.class.st
@@ -12,14 +12,14 @@ ToOverlayWindowManagerTest >> testDefaultSizeHook [
 
 	| e windowManager win |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 	windowManager := ToAnchoredWindowManager overlay.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self
 		assert: win measuredBounds inSpace extent
 		equals: e bounds inSpace extent
@@ -30,20 +30,18 @@ ToOverlayWindowManagerTest >> testElementEventHandlerClass [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToAnchoredWindowManager overlay.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: win anchorElement equals: e.
 	self assert: (e eventDispatcher hasEventHandlerSuchThat: [ :eh |
-			 eh isKindOf: ToAnchoredWindowManager ]).
-	win close.
+		eh isKindOf: ToAnchoredWindowManager ]).
+	space deferAndSettle: [ win close ].
 	self assert: (e eventDispatcher hasEventHandlerSuchThat: [ :eh |
-			 eh isKindOf: ToAnchoredWindowManager ])
+		eh isKindOf: ToAnchoredWindowManager ])
 ]
 
 { #category : #tests }
@@ -51,16 +49,16 @@ ToOverlayWindowManagerTest >> testElementExtentChangedEvent [
 
 	| e windowManager win |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
 	windowManager := ToAnchoredWindowManager overlay.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ win popup ].
 	self assert: win bounds inSpace extent equals: 10 asPoint.
-	e extent: 100 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e extent: 100 asPoint ].
 	self assert: win bounds inSpace extent equals: 100 asPoint
 ]

--- a/src/Toplo-Tests/ToOverlayWindowTest.class.st
+++ b/src/Toplo-Tests/ToOverlayWindowTest.class.st
@@ -12,20 +12,21 @@ ToOverlayWindowTest >> testWindowSize [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	windowManager := ToAnchoredWindowManager overlay windowBuilder: [
-		                 :anchWin
-		                 :requestEvent |  ].
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
+	windowManager :=
+		ToAnchoredWindowManager overlay
+			windowBuilder: [ :anchWin :requestEvent |  ];
+			yourself.
 	e addEventHandler: windowManager.
-	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		win := windowManager createNewWindowOnEvent: nil.
+		win popup ].
 	self assert: win bounds inSpace extent equals: 10 asPoint.
 
-	e extent: 20 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e extent: 20 asPoint ].
 	self assert: win bounds inSpace extent equals: 20 asPoint
 ]
 
@@ -34,20 +35,21 @@ ToOverlayWindowTest >> testWindowSize2 [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	e position: 10 asPoint.
-	e extent: 10 asPoint.
-	windowManager := ToAnchoredWindowManager overlay windowBuilder: [
-		                 :anchWin
-		                 :requestEvent |
-		                 anchWin root addChild:
-			                 (ToElement new extent: 100 asPoint) ].
+	space deferAndSettle: [
+		space root addChild: e.
+		e position: 10 asPoint.
+		e extent: 10 asPoint ].
+	windowManager :=
+		ToAnchoredWindowManager overlay
+			windowBuilder: [ :anchWin :requestEvent |
+				anchWin root addChild: (ToElement new extent: 100 asPoint) ];
+			yourself.
 	e addEventHandler: windowManager.
-	win := windowManager createNewWindowOnEvent: nil.
-	win popup.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		win := windowManager createNewWindowOnEvent: nil.
+		win popup ].
 	self assert: win bounds inSpace extent equals: 10 asPoint.
-	e extent: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e extent: 20 asPoint ].
 	self assert: win bounds inSpace extent equals: 20 asPoint
 ]

--- a/src/Toplo-Tests/ToParameterizedHostTest.class.st
+++ b/src/Toplo-Tests/ToParameterizedHostTest.class.st
@@ -7,44 +7,10 @@ Class {
 	#category : #'Toplo-Tests-Core'
 }
 
-{ #category : #tests }
-ToParameterizedHostTest >> applyAllEnqueuedStates [
-
-	testingSpaces ifNil: [ ^ self ].
-	testingSpaces do: [ :each | 
-		each applyAllSkinInstallers.
-		each applyAllEnqueuedStates. 
-		each requestNextPulse ].
-]
-
 { #category : #running }
-ToParameterizedHostTest >> setUp [ 
+ToParameterizedHostTest >> setUp [
 
 	super setUp.
-	space := self newTestingSpace. 
-
-]
-
-{ #category : #tests }
-ToParameterizedHostTest >> testingSpace: aSpace showThenDo: aBlock [
-
-	aSpace show.
-	BlSpace
-		pulseUntilSpaceOpenedAndEmptyTaskQueue: aSpace
-		timeout: 200 milliSeconds.
-	aBlock value.
-	aSpace close
-]
-
-{ #category : #tests }
-ToParameterizedHostTest >> waitTestingSpaces [
-
-	self waitTestingSpacesTimeout: 200 milliSeconds
-]
-
-{ #category : #tests }
-ToParameterizedHostTest >> waitTestingSpacesTimeout: aDuration [
-
-	testingSpaces do: [ :each |
-		BlSpace pulseUntilEmptyTaskQueue: each timeout: aDuration ]
+	space := self newTestingSpace.
+	space windowExtent: 800@600
 ]

--- a/src/Toplo-Tests/ToPopupWindowManagerTest.class.st
+++ b/src/Toplo-Tests/ToPopupWindowManagerTest.class.st
@@ -27,13 +27,11 @@ ToPopupWindowManagerTest >> testAutoClosePickOutsideEventClass [
 	| e windowManager closed |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	closed := false.
@@ -44,10 +42,10 @@ ToPopupWindowManagerTest >> testAutoClosePickOutsideEventClass [
 	two mouseUp are necessary because by default, windowManager popupOnMouseDown is true.
 	have a look at ToPopupPickOutsideEventFilter>>mouseUpEvent:
 	"
-	BlSpace simulateMouseUpOn: space root.
-	BlSpace simulateMouseDownOn: space root.
+	space root eventSimulator mouseUp.
+	space root eventSimulator mouseDown.
 	windowManager autoCloseDelay asDelay wait.
-	BlSpace simulateMouseUpOn: space root.
+	space root eventSimulator mouseUp.
 	" window is closed on mouse-up-outside"
 	self assert: windowManager currentWindow isNil.
 	self assert: closed
@@ -58,14 +56,13 @@ ToPopupWindowManagerTest >> testElementEventHandlerClass [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	win popup.
-	self waitTestingSpaces.
+	space settle.
 	self assert: win anchorElement equals: e.
 	self assert: win manager currentWindow identicalTo: win.
 	win close.
@@ -77,19 +74,18 @@ ToPopupWindowManagerTest >> testElementPositionInSpaceChangedEvent [
 
 	| win e windowManager |
 	e := ToElement new.
-	space root addChild: e.
 	e position: 10 asPoint.
 	e extent: 10 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	win popup.
-	self waitTestingSpaces.
+	space settle.
 	self assert: win isOpened.
-	e position: 20 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e position: 20 asPoint ].
 	self assert: win isOpened
 ]
 
@@ -99,8 +95,7 @@ ToPopupWindowManagerTest >> testMouseDownEvent [
 	| e windowManager position event |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
@@ -108,9 +103,8 @@ ToPopupWindowManagerTest >> testMouseDownEvent [
 	position := e bounds inSpace center.
 	event := BlMouseDownEvent primary position: position.
 	e dispatchEvent: event.
-	self waitTestingSpaces.
+	space settle.
 	self assert: windowManager currentWindow notNil.
-	self waitTestingSpaces.
 	self assert: windowManager currentWindow isOpened
 ]
 
@@ -120,14 +114,12 @@ ToPopupWindowManagerTest >> testMouseDownInElementEvent [
 	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened
 ]
@@ -138,14 +130,12 @@ ToPopupWindowManagerTest >> testMouseUpEvent [
 	| e windowManager closed position event |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	closed := false.
@@ -157,7 +147,7 @@ ToPopupWindowManagerTest >> testMouseUpEvent [
 	event := BlMouseUpEvent primary position: position.
 	event fillFromTime: e space time.
 	e dispatchEvent: event.
-	self waitTestingSpaces.
+	space settle.
 
 	" window is closed on mouse-up "
 	self assert: windowManager currentWindow isNil.
@@ -170,14 +160,12 @@ ToPopupWindowManagerTest >> testMouseUpInElementEvent [
 	| e windowManager closed |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	closed := false.
@@ -185,7 +173,7 @@ ToPopupWindowManagerTest >> testMouseUpInElementEvent [
 			 on: ToClosedEvent
 			 do: [ :event | closed := true ]).
 	(windowManager autoCloseDelay + 1 milliSecond) wait.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseUp.
 	" window is closed on mouse-up "
 	self assert: windowManager currentWindow isNil.
 	self assert: closed
@@ -197,14 +185,12 @@ ToPopupWindowManagerTest >> testMouseUpInElementEventAfterLongDelayShouldCloseWi
 	| e windowManager closed |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	closed := false.
@@ -212,7 +198,7 @@ ToPopupWindowManagerTest >> testMouseUpInElementEventAfterLongDelayShouldCloseWi
 			 on: ToClosedEvent
 			 do: [ :event | closed := true ]).
 	(windowManager autoCloseDelay + 1 milliSecond) wait.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseUp.
 	" window is closed on mouse-up "
 	self assert: windowManager currentWindow isNil.
 	self assert: closed
@@ -225,14 +211,12 @@ ToPopupWindowManagerTest >> testMouseUpOutsideEvent [
 	e := ToElement new.
 	e extent: 100 asPoint.
 	e position: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	closed := false.
@@ -244,7 +228,7 @@ ToPopupWindowManagerTest >> testMouseUpOutsideEvent [
 		         position: 0 @ 0;
 		         fillFromTime: space time.
 	e dispatchEvent: event.
-	self waitTestingSpaces.
+	space settle.
 
 	" window is closed on mouse-up "
 	self assert: windowManager currentWindow isNil.
@@ -257,8 +241,7 @@ ToPopupWindowManagerTest >> testNoAutoCloseEvenAfterLongDelay [
 	| e windowManager closed |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e  ].
 
 	windowManager := ToPopupWindowManager new.
 	closed := false.
@@ -270,29 +253,25 @@ ToPopupWindowManagerTest >> testNoAutoCloseEvenAfterLongDelay [
 			 do: [ :event | closed := true ]).
 
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseUp.
 	" window is not closed on mouse-up "
-	self waitTestingSpaces.
 	self assert: windowManager currentWindow notNil.
 	self deny: closed.
 
 	windowManager autoCloseDelay: 400 milliSeconds.
 	closed := false.
-	BlSpace simulateMouseDownOn: e.
-	BlSpace simulateMouseUpOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow notNil.
 	self deny: closed.
 
 	closed := false.
-	BlSpace simulateMouseDownOn: e.
-	800 milliSeconds asDelay wait.
-	BlSpace simulateMouseUpOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
+	space waitForDuration: 400 milliSeconds.
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow isNil.
 	self assert: closed
 ]
@@ -312,45 +291,36 @@ ToPopupWindowManagerTest >> testOnUninstalledIn [
 	| e windowManager |
 	e := ToElement new.
 	windowManager := ToPopupWindowManager new.
-	e addEventHandler: windowManager.
-
+	e addEventHandler: windowManager
 ]
 
 { #category : #tests }
 ToPopupWindowManagerTest >> testUseNoMouseButton [
 
-	| e windowManager event |
+	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	windowManager useNoMouseButton.
 	e addEventHandler: windowManager.
-	event := BlMouseDownEvent primary.
-	event position: e bounds inSpace center.
-	BlSpace simulateEvent: event on: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow isNil
 ]
 
 { #category : #tests }
 ToPopupWindowManagerTest >> testUsePrimaryMouseButton [
 
-	| e windowManager event |
+	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	windowManager usePrimaryMouseButton.
 	e addEventHandler: windowManager.
-	event := BlMouseDownEvent primary.
-	event position: e bounds inSpace center.
-	BlSpace simulateEvent: event on: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened
 ]
@@ -358,37 +328,30 @@ ToPopupWindowManagerTest >> testUsePrimaryMouseButton [
 { #category : #tests }
 ToPopupWindowManagerTest >> testUsePrimaryMouseButton2 [
 
-	| e windowManager event |
+	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	windowManager usePrimaryMouseButton.
 	e addEventHandler: windowManager.
-	event := BlMouseDownEvent secondary.
-	event position: e bounds inSpace center.
-	BlSpace simulateEvent: event on: e.
+	e eventSimulator mouseDownButton: BlMouseButton secondary.
 	self assert: windowManager currentWindow isNil
 ]
 
 { #category : #tests }
 ToPopupWindowManagerTest >> testUseSecondaryMouseButton [
 
-	| e windowManager event |
+	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	windowManager useSecondaryMouseButton.
 	e addEventHandler: windowManager.
-	event := BlMouseDownEvent secondary.
-	event position: e bounds inSpace center.
-	BlSpace simulateEvent: event on: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDownButton: BlMouseButton secondary.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened
 ]
@@ -396,17 +359,14 @@ ToPopupWindowManagerTest >> testUseSecondaryMouseButton [
 { #category : #tests }
 ToPopupWindowManagerTest >> testUseSecondaryMouseButton2 [
 
-	| e windowManager event |
+	| e windowManager |
 	e := ToElement new.
 	e extent: 100 asPoint.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	windowManager useSecondaryMouseButton.
 	e addEventHandler: windowManager.
-	event := BlMouseDownEvent primary.
-	event position: e bounds inSpace center.
-	BlSpace simulateEvent: event on: e.
+	e eventSimulator mouseDown.
 	self assert: windowManager currentWindow isNil
 ]

--- a/src/Toplo-Tests/ToPopupWindowTest.class.st
+++ b/src/Toplo-Tests/ToPopupWindowTest.class.st
@@ -14,32 +14,29 @@ ToPopupWindowTest >> testElement [
 	e := ToElement new
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
-	space root addChild: e.
+		     position: 50 @ 50;
+		     yourself.
+	space deferAndSettle: [ space root addChild: e ].
 
-	" have to layout the space here to ensure that no position changed event is sent (which should close the window and fail the test)"
-	self waitTestingSpaces.
-	windowManager := ToPopupWindowManager new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+	windowManager := ToPopupWindowManager new.
+	windowManager windowBuilder: [ :anchWin :element |  ].
 	e addEventHandler: windowManager.
 	win := windowManager createNewWindowOnEvent: nil.
 	win popup.
-
-	self waitTestingSpaces.
+	space settle.
 	self assert: win anchorElement equals: e.
 	self assert: win isOpened.
 	win close.
-	self waitTestingSpaces.
+	space settle.
 	self assert: win isClosed.
 
 	win := windowManager createNewWindowOnEvent: nil.
 	win popup.
-	self waitTestingSpaces.
+	space settle.
 	self assert: win anchorElement equals: e.
 	self assert: win isOpened.
 	win close.
-	self waitTestingSpaces.
+	space settle.
 	self assert: win isClosed
 ]
 
@@ -51,29 +48,29 @@ ToPopupWindowTest >> testElementWithLabelEditorAndPopupWindowManager [
 		     text: 'a text that can be edited';
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
+		     position: 50 @ 50;
+		     yourself.
 	e isEditable: true.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 
 	windowManager := ToPopupWindowManager new.
 	e addEventHandler: windowManager.
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
 
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 
-	self waitTestingSpaces.
 	e popupEditorEvent: nil.
 
-	self waitTestingSpaces.
+	space waitUntilTrue: [ e editorWindowManager notNil ].
 	self assert: e editorWindowManager notNil.
 	self assert: e editorWindowManager editor notNil.
 	self
 		assert: e editorWindowManager editor text asString
 		equals: e text asString.
 	e editorWindowManager currentWindow close.
-	self assert: e editorWindowManager currentWindow isNil.
+	space waitUntilTrue: [ e editorWindowManager currentWindow isNil ].
 	self assert: e editorWindowManager editor isNil
 ]
 
@@ -84,13 +81,12 @@ ToPopupWindowTest >> testElementWithTooltipAndPopupWindowManager [
 	e := ToElement new
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
-	space root addChild: e.
-	self waitTestingSpaces.
+		     position: 50 @ 50;
+		     yourself.
+	space deferAndSettle: [ space root addChild: e ].
 
-	windowManager := ToPopupWindowManager new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+	windowManager := ToPopupWindowManager new.
+	windowManager windowBuilder: [ :anchWin :element |  ].
 	e addEventHandler: windowManager.
 	e tooltipBuilder: [ :win :request |
 		win root addChild: (ToLabel text: 'Tooltip content') ].
@@ -98,22 +94,21 @@ ToPopupWindowTest >> testElementWithTooltipAndPopupWindowManager [
 	self assert: tooltipWindowManager notNil.
 
 	" mouse down immediately followed by a mouse up -> the popup should stay opened"
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	self assert: windowManager currentWindow isOpened.
 	self assert: tooltipWindowManager currentWindow isNil.
-	BlSpace simulateMouseUpOn: e.
-	self waitTestingSpacesTimeout: 400 milliSeconds.
+	e eventSimulator mouseUp.
+	space waitForDuration: 400 milliSeconds.
 	self assert: windowManager currentWindow isOpened.
+	space waitForDuration: 150 milliSeconds.
 
-	150 milliSecond wait.
-
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpaces.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	self assert: windowManager currentWindow isOpened.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseUp.
 
-	self waitTestingSpaces.
+	space waitUntilTrue: [ windowManager currentWindow isNil ].
 	self assert: windowManager currentWindow isNil
 ]
 
@@ -124,38 +119,40 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseDownDelayUp [
 	e := ToElement new
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
-	space root addChild: e.
-	self waitTestingSpaces.
+		     position: 50 @ 50;
+		     yourself.
+	space deferAndSettle: [ space root addChild: e ].
 
-	windowManager := ToPopupWindowManager new windowBuilder: [
-		                 :anchWin
-		                 :element |  ].
+	windowManager := ToPopupWindowManager new.
+	windowManager windowBuilder: [ :anchWin :element |  ].
 	e addEventHandler: windowManager.
 
 	" mouse down immediately followed by a mouse up -> the popup should stay opened"
-	BlSpace simulateMouseDownOn: e.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 
 	windowManager autoCloseDelay: 200 milliSeconds.
 
 	" mouse down then waiting for a delay < autoclose delay then a mouse up -> the popup should stay opened"
-	BlSpace simulateMouseDownOn: e.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
-	self waitTestingSpacesTimeout: 50 milliSeconds.
-	BlSpace simulateMouseUpOn: e.
+	space waitForDuration: 50 milliSeconds.
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 	
 	" mouse down then waiting for a delay > autoclose delay then a mouse up -> the popup should be closed"
-	BlSpace simulateMouseDownOn: e.
-	self waitTestingSpacesTimeout: 300 milliSeconds.
+	e eventSimulator mouseDown.
+	space waitForDuration: 300 milliSeconds.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseUp.
+	space waitUntilTrue: [ windowManager currentWindow isNil ].
 	self assert: windowManager currentWindow isNil
 ]
 
@@ -166,13 +163,13 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseDownOutside [
 	e := ToElement new
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
-	space root addChild: e.
+		     position: 50 @ 50;
+		     yourself.
+	space deferAndSettle: [ space root addChild: e ].
 
-	windowManager := ToPopupWindowManager new windowBuilder: [
-		                 :anchWin
-		                 :element |
-		                 anchWin addChild: (ToElement new extent: 20 @ 20) ].
+	windowManager := ToPopupWindowManager new.
+	windowManager windowBuilder: [ :anchWin :element |
+		anchWin addChild: (ToElement new extent: 20 @ 20) ].
 	e addEventHandler: windowManager.
 
 	closed := false.
@@ -181,13 +178,15 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseDownOutside [
 			 do: [ :event | closed := true ]).
 			
 	windowManager autoCloseDelay: 200 milliSeconds.
-	BlSpace simulateMouseDownOn: e.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow notNil.
 
-	BlSpace simulateMouseDownOn: space root.
-	400 milliSeconds asDelay wait.
-	BlSpace simulateMouseUpOn: space root.
+	space root eventSimulator mouseDown.
+	space waitForDuration: 400 milliSeconds.
+	space root eventSimulator mouseUp.
+	space waitUntilTrue: [ windowManager currentWindow isNil ].
 	self assert: closed.
 	self assert: windowManager currentWindow isNil
 ]
@@ -199,43 +198,41 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseUpOutsideOnASibling [
 	e := ToElement new
 		     background: Color red;
 		     extent: 100 @ 40;
-		     position: 50 @ 50.
+		     position: 50 @ 50;
+		     yourself.
 	other := ToElement new
 		         background: Color blue;
 		         extent: 50 @ 50;
-		         position: 500 @ 500.
-	space root addChild: e.
-	space root addChild: other.
+		         position: 500 @ 500;
+		         yourself.
+	space deferAndSettle: [
+		space root addChild: e.
+		space root addChild: other ].
 
-	windowManager := ToPopupWindowManager new windowBuilder: [
-		                 :anchWin
-		                 :element |
-		                 anchWin addChild: (ToElement new extent: 100 @ 100) ].
+	windowManager := ToPopupWindowManager new.
+	windowManager windowBuilder: [ :anchWin :element |
+		anchWin addChild: (ToElement new extent: 100 @ 100) ].
 	e addEventHandler: windowManager.
 	windowManager autoCloseDelay: 100 milliSeconds.
-
-	self waitTestingSpaces.
 	" mouse down on widget then up on popup"
-	BlSpace simulateMouseDownOn: e.
-	BlSpace simulateMouseUpOn: e.
+	e eventSimulator mouseDown.
+	space waitUntilTrue: [ windowManager currentWindow notNil ].
+	e eventSimulator mouseUp.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
 
-	BlSpace simulateMouseDownOn: windowManager currentWindow.
-	BlSpace simulateMouseUpOn: windowManager currentWindow.
-	self waitTestingSpacesTimeout: 300 milliSeconds.
-	100 milliSeconds asDelay wait.
+	windowManager currentWindow eventSimulator mouseDown.
+	windowManager currentWindow eventSimulator mouseUp.
+	space waitForDuration: 400 milliSeconds.
 	self assert: windowManager currentWindow notNil.
 	self assert: windowManager currentWindow isOpened.
-	self waitTestingSpaces.
+
 	closed := false.
-	e addEventHandler: (BlEventHandler
-			 on: ToClosedEvent
-			 do: [ :event | closed := true ]).
-	BlSpace simulateMouseDownOn: other.
-	400 milliSeconds asDelay wait.
-	BlSpace simulateMouseUpOn: other.
-	self waitTestingSpaces.
+	e addEventHandlerOn: ToClosedEvent do: [ :event | closed := true ].
+	other eventSimulator mouseDown.
+	space waitForDuration: 400 milliSeconds.
+	other eventSimulator mouseUp.
+	space waitUntilTrue: [ windowManager currentWindow isNil ].
 	self assert: closed.
 	self assert: windowManager currentWindow isNil
 ]

--- a/src/Toplo-Tests/ToPropertyWriterTest.class.st
+++ b/src/Toplo-Tests/ToPropertyWriterTest.class.st
@@ -54,7 +54,7 @@ ToPropertyWriterTest >> testAnimationNeedPropertyWithReader [
 	propWriter animation: anim.
 	propWriter writeTo: w.
 
-	self waitTestingSpacesTimeout: 300 milliSeconds.
+	space waitUntilTrue: [ onFinishedDone ] forDuration: 1 second.
 	self assert: onFinishedDone
 ]
 
@@ -147,7 +147,7 @@ ToPropertyWriterTest >> testReceiveEventWithFeaturePropertyWithAnimationWithRawV
 	propWriter eventClass: ToHoveredSkinEvent.
 	propWriter animation: (anim := ToBackgroundColorAnimationForTest new property: prop).
 	target := BlElement new.
-	space root addChild: target.
+	space deferAndSettle: [ space root addChild: target ].
 	wasHere := false.
 	anim onFinishedDo: [ :w |
 		wasHere := true.
@@ -155,8 +155,8 @@ ToPropertyWriterTest >> testReceiveEventWithFeaturePropertyWithAnimationWithRawV
 		self assert: target background paint color equals: Color blue.
 		self assert: (prop read: target) equals: target background ].
 	propWriter receiveEvent: (ToHoveredSkinEvent new currentTarget: target).
-	" have to wait animation termination ".
-	self waitTestingSpaces.
+	" have to wait animation termination "
+	space settle.
 	self assert: wasHere.
 	self assert: target background paint color equals: Color blue
 ]
@@ -173,7 +173,7 @@ ToPropertyWriterTest >> testReceiveEventWithFeaturePropertyWithAnimationWithValu
 	propWriter eventClass: ToHoveredSkinEvent.
 	propWriter animation: (anim := ToBackgroundColorAnimationForTest new property: prop).
 	target := BlElement new.
-	space root addChild: target.
+	space deferAndSettle: [ space root addChild: target ].
 	wasHere := false.
 	anim onFinishedDo: [ :w |
 		wasHere := true.
@@ -185,7 +185,7 @@ ToPropertyWriterTest >> testReceiveEventWithFeaturePropertyWithAnimationWithValu
 	self assert: target2 identicalTo: target.
 	" have to wait animation termination "
 	self assert: target background paint isNil.
-	self waitTestingSpaces.
+	space settle.
 	self assert: wasHere.
 	self assert: target background paint color equals: Color blue
 ]
@@ -263,7 +263,7 @@ ToPropertyWriterTest >> testWithFeaturePropertyAndAnimation [
 
 	| w prop propWriter anim wasHere |
 	w := BlElement new.
-	space root addChild: w.
+	space deferAndSettle: [ space root addChild: w ].
 	prop := ToFeatureProperty new.
 	prop name: #background.
 	propWriter := ToPropertyWriter new.
@@ -277,7 +277,7 @@ ToPropertyWriterTest >> testWithFeaturePropertyAndAnimation [
 		self assert: w background paint color equals: Color blue.
 		self assert: (prop read: w) equals: w background ].
 	propWriter writeTo: w.
-	self waitTestingSpaces.
+	space settle.
 	self assert: wasHere
 ]
 
@@ -337,7 +337,7 @@ ToPropertyWriterTest >> testWithPseudoPropertyAndAnimation [
 
 	| w prop propWriter anim wasHere |
 	w := BlElement new.
-	space root addChild: w.
+	space deferAndSettle: [ space root addChild: w ].
 	prop := ToPseudoProperty new.
 	prop writer: [ :e :v | e background: v ].
 	prop reader: [ :e | e background ].
@@ -353,7 +353,7 @@ ToPropertyWriterTest >> testWithPseudoPropertyAndAnimation [
 		self assert: w background paint color equals: Color blue.
 		self assert: (prop read: w) equals: w background ].
 	propWriter writeTo: w.
-	self waitTestingSpaces.
+	space settle.
 	self assert: wasHere
 ]
 
@@ -362,7 +362,7 @@ ToPropertyWriterTest >> testWithPseudoPropertyWithValuableAndAnimation [
 
 	| w prop propWriter anim w2 wasHere |
 	w := BlElement new.
-	space root addChild: w.
+	space deferAndSettle: [ space root addChild: w ].
 	prop := ToPseudoProperty new.
 	prop writer: [ :e :v | e background: v ].
 	prop reader: [ :e | e background ].
@@ -379,7 +379,7 @@ ToPropertyWriterTest >> testWithPseudoPropertyWithValuableAndAnimation [
 		self assert: w background paint color equals: Color blue.
 		self assert: (prop read: w) equals: w background ].
 	propWriter writeTo: w.
-	self waitTestingSpaces.
+	space settle.
 	self assert: wasHere
 ]
 

--- a/src/Toplo-Tests/ToRawSkinTest.class.st
+++ b/src/Toplo-Tests/ToRawSkinTest.class.st
@@ -31,8 +31,7 @@ ToRawSkinTest >> testBasicStyleSheet [
 				write: #background asWritableProperty
 				with: Color red ].
 	e styleSheet: styleSheet.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e background paint color equals: Color red
 ]
 
@@ -48,8 +47,7 @@ ToRawSkinTest >> testButtonWithStyleSheet [
 				write: #background asWritableProperty
 				with: Color red ].
 	e styleSheet: styleSheet.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e background paint color equals: Color red
 ]
 

--- a/src/Toplo-Tests/ToScriptableSkinTest.class.st
+++ b/src/Toplo-Tests/ToScriptableSkinTest.class.st
@@ -18,10 +18,9 @@ ToScriptableSkinTest >> testOnHoveredSkinEvent [
 			e extent: 30 asPoint.
 			e background: Color yellow ].
 	te defaultSkin: skin.
-	space root addChild: te.
+	space deferAndSettle: [ space root addChild: te ].
 	space startToploPhases.
-	BlSpace simulateMouseMoveInside: te.
-	self waitTestingSpaces.
+	te eventSimulator mouseMoveInside.
 	self assert: te background paint color equals: Color yellow.
 	self assert: te extent equals: 30 asPoint
 ]
@@ -36,9 +35,9 @@ ToScriptableSkinTest >> testOnInstalledSkinEvent [
 			e extent: 30 asPoint.
 			e background: Color yellow ].
 	te defaultSkin: skin.
-	space root addChild: te.
+	space deferAndSettle: [ space root addChild: te ].
 	space startToploPhases.
-	self waitTestingSpaces.
+	space settle.
 	self assert: te background paint color equals: Color yellow.
 	self assert: te extent equals: 30 asPoint
 ]
@@ -54,11 +53,10 @@ ToScriptableSkinTest >> testOnLeftSkinEvent [
 			e extent: 30 asPoint.
 			e background: Color yellow ].
 	te defaultSkin: skin.
-	space root addChild: te.
+	space deferAndSettle: [ space root addChild: te ].
 	space startToploPhases.
-	BlSpace simulateMouseMoveInside: te.
-	BlSpace simulateMouseMoveOutside: te.
-	self waitTestingSpaces.
+	te eventSimulator mouseMoveInside.
+	te eventSimulator mouseMoveOutside.
 	self assert: te background paint color equals: Color yellow.
 	self assert: te extent equals: 30 asPoint
 ]

--- a/src/Toplo-Tests/ToShrinkableContainerTest.class.st
+++ b/src/Toplo-Tests/ToShrinkableContainerTest.class.st
@@ -14,8 +14,7 @@ ToShrinkableContainerTest >> testContainerSizeChange [
 	e := self testShrinkableContainerNotVisible.
 	" make the container size smaller than the child size
 	this makes the shrink layer visible"
-	e extent: 20 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e extent: 20 asPoint ].
 	self
 		assert: e shrinkFeedbackLayer visibility
 		equals: BlVisibility visible.
@@ -27,12 +26,12 @@ ToShrinkableContainerTest >> testEnableShrinkLayer [
 
 	| e  |
 	e := ToShrinkableContainer new.
-	space root addChild: e.
-	e enableShrinkLayer: true.
+	space deferAndSettle: [
+		space root addChild: e.
+		e enableShrinkLayer: true ].
 	self assert: e shrinkFeedbackLayer notNil.
 	self assert: (e shrinkFeedbackLayer isKindOf: ToShrinkFeedbackLayer).
 	self assert: e shrinkFeedbackLayer visibility equals: BlVisibility hidden.
-	self waitTestingSpaces.
 	^ e
 ]
 
@@ -41,10 +40,12 @@ ToShrinkableContainerTest >> testEnableShrinkLayer2 [
 
 	| e  |
 	e := ToShrinkableContainer new.
-	space root addChild: e.
-	e enableShrinkLayer: true.
+	space deferAndSettle: [
+		space root addChild: e.
+		e enableShrinkLayer: true ].
 	self assert: e shrinkFeedbackLayer notNil.
-	e enableShrinkLayer: false.
+
+	space deferAndSettle: [ e enableShrinkLayer: false ].
 	self assert: e shrinkFeedbackLayer isNil.
 	^ e
 ]
@@ -55,9 +56,10 @@ ToShrinkableContainerTest >> testIsShrinked [
 	| e child |
 	e := ToShrinkableContainer new.
 	e extent: 100 asPoint.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e isShrinked.
-	e enableShrinkLayer: true.
+
+	space deferAndSettle: [ e enableShrinkLayer: true ].
 	self deny: e isShrinked.
 
 	child := ToElement new.
@@ -65,12 +67,10 @@ ToShrinkableContainerTest >> testIsShrinked [
 	" make the child size less than the container size
 	this let the shrink layer invisible"
 	child extent: 50 asPoint.
-	e addChild: child.
-
-	self waitTestingSpaces.
+	space deferAndSettle: [ e addChild: child ].
 	self deny: e isShrinked.
-	child extent: 150 asPoint.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child extent: 150 asPoint ].
 	self assert: e isShrinked.
 	^ e
 ]
@@ -83,20 +83,19 @@ ToShrinkableContainerTest >> testIsShrinkedHorizontally [
 	" horizontal is the default "
 	e checkHorizontalShrinkability.
 	e width: 100.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	child id: #child.
 	" make the child size less than the container size
 	this let the shrink layer invisible"
 	child width: 50.
-	e addChild: child.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e addChild: child ].
 	self deny: e isShrinked.
-	child width: 150.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child width: 150 ].
 	self assert: e isShrinked.
-	e width: 200.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e width: 200 ].
 	self deny: e isShrinked.
 	^ e
 ]
@@ -109,20 +108,19 @@ ToShrinkableContainerTest >> testIsShrinkedHorizontally2 [
 	" horizontal is the default "
 	e checkHorizontalShrinkability.
 	e height: 100.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	child id: #child.
 	" make the child size less than the container size
 	this let the shrink layer invisible"
 	child height: 50.
-	e addChild: child.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e addChild: child ].
 	self deny: e isShrinked.
-	child height: 150.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child height: 150 ].
 	self deny: e isShrinked.
-	e height: 200.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e height: 200 ].
 	self deny: e isShrinked.
 	^ e
 ]
@@ -135,20 +133,19 @@ ToShrinkableContainerTest >> testIsShrinkedVertically [
 	" horizontal is the default "
 	e checkVerticalShrinkability.
 	e height: 100.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	child id: #child.
 	" make the child size less than the container size
 	this let the shrink layer invisible"
 	child height: 50.
-	e addChild: child.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e addChild: child ].
 	self deny: e isShrinked.
-	child height: 150.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child height: 150 ].
 	self assert: e isShrinked.
-	e height: 200.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e height: 200 ].
 	self deny: e isShrinked.
 	^ e
 ]
@@ -161,20 +158,19 @@ ToShrinkableContainerTest >> testIsShrinkedVertically2 [
 	" horizontal is the default "
 	e checkVerticalShrinkability.
 	e width: 100.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	child := ToElement new.
 	child id: #child.
 	" make the child size less than the container size
 	this let the shrink layer invisible"
 	child width: 50.
-	e addChild: child.
-	self waitTestingSpaces.
+	space deferAndSettle: [ e addChild: child ].
 	self deny: e isShrinked.
-	child width: 150.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ child width: 150 ].
 	self deny: e isShrinked.
-	e width: 200.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ e width: 200 ].
 	self deny: e isShrinked.
 	^ e
 ]
@@ -193,8 +189,7 @@ ToShrinkableContainerTest >> testShrinkableContainerNotVisible [
 	this let the shrink layer invisible"
 	child extent: 50 asPoint.
 	e addChild: child.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e shrinkFeedbackLayer parent equals: e.
 	self
 		assert: e shrinkFeedbackLayer visibility
@@ -210,8 +205,7 @@ ToShrinkableContainerTest >> testShrinkableContainerVisible [
 	child := e childWithId: #child.
 	" make the child size greater than the container size
 	this makes the shrink layer visible"
-	child extent: 150 asPoint.
-	self waitTestingSpaces.
+	space deferAndSettle: [ child extent: 150 asPoint ].
 	self
 		assert: e shrinkFeedbackLayer visibility
 		equals: BlVisibility visible.

--- a/src/Toplo-Tests/ToSkinInstallerTest.class.st
+++ b/src/Toplo-Tests/ToSkinInstallerTest.class.st
@@ -7,7 +7,7 @@ Class {
 { #category : #tests }
 ToSkinInstallerTest >> testApplyOn [
 
-	| e |
+	| e isThemeSkin |
 	e := ToElement new.
 	self
 		should: [ e skinManager forceNewSkinRequested: true in:  e ]
@@ -19,15 +19,17 @@ ToSkinInstallerTest >> testApplyOn [
 	" need to reset the skin to the initial (unknown skin) because 
 	the previous error let the skinManager in an invalid state"
 	e skinManager uninstallSkinIn: e.
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
-	self assert: e skinManager installedSkin isThemeSkin
+	space deferAndSettle: [
+		space root addChild: e.
+		e skinManager installNewSkinIn: e.
+		isThemeSkin := e skinManager installedSkin isThemeSkin ].
+	self assert: isThemeSkin
 ]
 
 { #category : #tests }
 ToSkinInstallerTest >> testApplyOnWithRawSkin [
 
-	| e |
+	| e styleInstalled newSkinRequested isUnresolvedSkin isThemeSkin styleInstalledAfter |
 	e := ToElementForRawSkinTest new.
 	space toTheme: ToRawTheme new.
 	self
@@ -36,25 +38,33 @@ ToSkinInstallerTest >> testApplyOnWithRawSkin [
 	" an element must be attached to a space 
 	because installing a skin requires a theme"
 	self should: [ e skinManager installNewSkinIn: e ] raise: ToSpaceNotFoundError.
-	self deny: e styleInstalled.
-	self assert: e skinManager newSkinRequested.
-	self assert: e skinManager installedSkin isUnresolvedSkin.
+	styleInstalled := e styleInstalled.
+	newSkinRequested := e skinManager newSkinRequested.
+	isUnresolvedSkin := e skinManager installedSkin isUnresolvedSkin.
+	self deny: styleInstalled.
+	self assert: newSkinRequested.
+	self assert: isUnresolvedSkin.
 	" need to reset the skin to the initial (unknown skin) because 
 	the previous error let the skinManager in an invalid state"
 	e skinManager uninstallSkinIn: e.
-	space root addChild: e.
-	e skinManager installNewSkinIn: e.
-	self assert: e skinManager installedSkin isThemeSkin.
-	self assert: e styleInstalled
+	space deferAndSettle: [
+		space root addChild: e.
+		e skinManager installNewSkinIn: e.
+		isThemeSkin := e skinManager installedSkin isThemeSkin.
+		styleInstalledAfter := e styleInstalled ].
+	self assert: isThemeSkin.
+	self assert: styleInstalledAfter
 ]
 
 { #category : #tests }
 ToSkinInstallerTest >> testInstallSkinInWithErrorNonAttachedInSpace [
 
-	| e |
+	| e newSkinRequested isThemeSkin |
 	e := ToElement new.
-	self deny: e skinManager newSkinRequested.
-	self deny: e skinManager installedSkin isThemeSkin.
+	newSkinRequested := e skinManager newSkinRequested.
+	isThemeSkin := e skinManager installedSkin isThemeSkin.
+	self deny: newSkinRequested.
+	self deny: isThemeSkin.
 	self
 		should: [ e skinManager forceNewSkinRequested: true in: e ]
 		raise: Error.

--- a/src/Toplo-Tests/ToSkinManagerTest.class.st
+++ b/src/Toplo-Tests/ToSkinManagerTest.class.st
@@ -10,16 +10,20 @@ Class {
 { #category : #tests }
 ToSkinManagerTest >> testApplySkinInstallerIn [
 
-	| e sk |
+	| e sk installedSkinIsThemeSkin newSkinRequested skinInstalledNewSkinRequestedAfter |
 	e := ToElement new.
-	space root addChild: e.
-	e skinManager uninstallSkinIn: e.
-	e defaultSkin: (sk := ToRawSkin new).
-	self assert: e skinManager installedSkin isThemeSkin.
-	self deny: e skinManager newSkinRequested.
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [
+		space root addChild: e.
+		e skinManager uninstallSkinIn: e.
+		e defaultSkin: (sk := ToRawSkin new).
+		installedSkinIsThemeSkin := e skinManager installedSkin isThemeSkin.
+		newSkinRequested := e skinManager newSkinRequested.
+		e skinManager installNewSkinIn: e.
+		skinInstalledNewSkinRequestedAfter := e skinManager newSkinRequested ].
+	self assert: installedSkinIsThemeSkin.
+	self deny: newSkinRequested.
 	self assert: e skinManager installedSkin identicalTo: sk.
-	self deny: e skinManager newSkinRequested
+	self deny: skinInstalledNewSkinRequestedAfter
 ]
 
 { #category : #tests }
@@ -28,26 +32,25 @@ ToSkinManagerTest >> testApplySkinInstallerIn2 [
 	| e |
 	e := ToElement new.
 	" no skinInstaller -> no installed skin  "
-	self waitTestingSpaces.
 	e ensuredSkinManager installNewSkinIn: e.
 	self deny: e skinManager installedSkin isThemeSkin.
 	e skinManager requestNewSkinIn: e.
-	self assert: e skinManager newSkinRequested.
-
+	self assert: e skinManager newSkinRequested
 ]
 
 { #category : #tests }
 ToSkinManagerTest >> testApplyStylesIn [
 
-	| e sk |
+	| e sk nextStatesIsEmpty |
 	e := ToElement new. 
-	space root addChild: e.
-	e skinManager uninstallSkinIn: e.
-	e defaultSkin: (sk := ToRawSkin new).
-	e skinManager installNewSkinIn: e.
+	space deferAndSettle: [
+		space root addChild: e.
+		e skinManager uninstallSkinIn: e.
+		e defaultSkin: (sk := ToRawSkin new).
+		e skinManager installNewSkinIn: e.
+		nextStatesIsEmpty := e skinManager skinStateQueue nextStates isEmpty ].
 	self assert: e skinManager installedSkin identicalTo: sk.
-	self assert: e skinManager skinStateQueue nextStates isEmpty.
-
+	self assert: nextStatesIsEmpty
 ]
 
 { #category : #tests }
@@ -66,14 +69,13 @@ ToSkinManagerTest >> testComputedStyleSheetChainIn [
 		assert:
 		(childchildchild bottomUpStyleSheetChain)
 		equals: #(  ).
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	" no styleSheet theme by default but any skin has a styleSheet"
 	self assert:
 		(childchildchild bottomUpStyleSheetChain )
 			size equals: 1.
-	space toTheme: ToStyleSheetTheme new.
-	self waitTestingSpaces.
 
+	space deferAndSettle: [ space toTheme: ToStyleSheetTheme new ].
 	" one style sheet in theme by default "
 	self assert:
 		(childchildchild bottomUpStyleSheetChain )
@@ -103,12 +105,13 @@ ToSkinManagerTest >> testDefaultSkin [
 
 	| e sk |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	e defaultSkin: (sk := ToRawSkin new).
 	self assert: e defaultSkin identicalTo: sk.
 	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
 	self assert: e skinManager installedSkin isThemeSkin.
-	self waitTestingSpaces.
+
+	space settle.
 	self
 		assert:
 			(e eventDispatcher handlers select: [ :h | h isKindOf: ToRawSkin ])
@@ -124,14 +127,14 @@ ToSkinManagerTest >> testElementRemovedFromSceneGraph [
 
 	| e sk |
 	e := ToElement new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e skinManager notNil.
 	e skinManagerDo: [ :sm | sk := sm installedSkin ].
 	self deny: sk isUnknownSkin.
-	space root removeChild: e.
-	space root addChild: e.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		space root removeChild: e.
+		space root addChild: e ].
 	e skinManagerDo: [ :sm | self deny: sm installedSkin identicalTo: sk ]
 ]
 
@@ -380,22 +383,16 @@ ToSkinManagerTest >> testRequestSkinInWithChildrenWhenInSpace [
 	childchild := ToElement new.
 	e addChild: child.
 	child addChild: childchild.
-	space root addChild: e.
-	" the skin is also Installed in children "
+
+	space deferAndSettle: [ space root addChild: e ].
+
+	" the skin is also installed in children "
 	self deny: e skinManager newSkinRequested.
-	self deny: child skinManager newSkinRequested.
-	self deny: childchild skinManager newSkinRequested.
-	self assert: child skinManager installedSkin isThemeSkin.
-	self assert: childchild skinManager installedSkin isThemeSkin.
-	self waitTestingSpaces.
 	self deny: child skinManager newSkinRequested.
 	self deny: childchild skinManager newSkinRequested.
 	self assert: e skinManager installedSkin isThemeSkin.
 	self assert: child skinManager installedSkin isThemeSkin.
-	self assert: childchild skinManager installedSkin isThemeSkin 
-
-	
-
+	self assert: childchild skinManager installedSkin isThemeSkin
 ]
 
 { #category : #tests }
@@ -403,13 +400,14 @@ ToSkinManagerTest >> testSetDefaultSkinIn [
 
 	| e sk |
 	e := ToElement new.
-	space root addChild: e.
-	e defaultSkin: (sk := ToRawSkin new).
+	space deferAndSettle: [
+		space root addChild: e.
+		e defaultSkin: (sk := ToRawSkin new) ].
 	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
 	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
 	self assert: e defaultSkin identicalTo: sk.
-	self assert: e skinManager installedSkin isThemeSkin.
-	self waitTestingSpaces.
+
+	space settle.
 	self
 		assert:
 			(e eventDispatcher handlers select: [ :h | h isKindOf: ToRawSkin ])
@@ -426,12 +424,11 @@ ToSkinManagerTest >> testSkinInstaller [
 	childchild := ToElement new.
 	e addChild: child.
 	child addChild: childchild.
-	self waitTestingSpaces.
 	self deny: e skinManager newSkinRequested.
 	self deny: child skinManager newSkinRequested.
 	self deny: childchild skinManager newSkinRequested.
-	space root addChild: e.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ space root addChild: e ].
 	" first skinInstaller is applied  "
 	self deny: e skinManager newSkinRequested.
 	self deny: child skinManager newSkinRequested.

--- a/src/Toplo-Tests/ToSkinStateGeneratorTest.class.st
+++ b/src/Toplo-Tests/ToSkinStateGeneratorTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToSkinStateGeneratorTest is a test class for testing the behavior of ToSkinStateGenerator
-"
 Class {
 	#name : #ToSkinStateGeneratorTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -14,11 +11,8 @@ ToSkinStateGeneratorTest >> newElementInSpace [
 	e := ToElement new.
 	self deny: e skinManager newSkinRequested.
 	e defaultSkin: ToRawSkin new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
-	" to install the element skin  "
-	space applyAllSkinInstallers.
-
 	^ e
 ]
 
@@ -111,7 +105,8 @@ ToSkinStateGeneratorTest >> testOnInstalledIn [
 		     ifNone: [  ].
 	self assert: h notNil.
 	self assert: h target identicalTo: e.
-	space root addChild: e
+
+	space deferAndSettle: [ space root addChild: e ]
 ]
 
 { #category : #tests }
@@ -128,7 +123,8 @@ ToSkinStateGeneratorTest >> testTarget [
 	gen := e eventDispatcher handlers detect: [ :h |
 		       h isKindOf: ToSkinStateGenerator ] ifNone: [].
 	self assert: gen notNil.
-	space root addChild: e.
+
+	space deferAndSettle: [ space root addChild: e ].
 	gen := e eventDispatcher handlers detect: [ :h |
 		       h isKindOf: ToSkinStateGenerator ].
 	self assert: gen notNil.
@@ -140,13 +136,14 @@ ToSkinStateGeneratorTest >> testWantsEvent [
 
 	| e gen  |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e isEnabled.
 	gen := e eventDispatcher handlers detect: [ :h |
 		       h isKindOf: ToSkinStateGenerator ].
 	gen eventsToHandle do: [ :cC |
 		self assert: (gen wantsEvent: (cC new currentTarget: e)) ].
-	e disable.
+
+	space deferAndSettle: [ e disable ].
 	self deny: e isEnabled.
 	gen eventsToHandle do: [ :cC | self assert: (gen wantsEvent: (cC new currentTarget: e)) ].
 ]

--- a/src/Toplo-Tests/ToSkinStateQueueTest.class.st
+++ b/src/Toplo-Tests/ToSkinStateQueueTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToSkinnableEventHandlerTest is a test class for testing the behavior of ToSkinnableEventHandler
-"
 Class {
 	#name : #ToSkinStateQueueTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -13,11 +10,9 @@ ToSkinStateQueueTest >> newElementInSpace [
 	| e |
 	e := ToElement new.
 	self deny: e skinManager newSkinRequested.
-	space root addChild: e.
-	self assert: e skinManager notNil.
-	" to install the element skin  "
-	space applyAllSkinInstallers.
 
+	space deferAndSettle: [ space root addChild: e ].
+	self assert: e skinManager notNil.
 	^ e
 ]
 
@@ -56,7 +51,7 @@ ToSkinStateQueueTest >> testEnqueueInstallStateFor [
 { #category : #tests }
 ToSkinStateQueueTest >> testEnqueueInstallStateForThroughARequest [
 
-	| q e sk isk |
+	| q e sk isk uninstalled installed |
 	e := self newElementInSpace.
 	isk := e skinManager installedSkin.
 	self assert: isk isThemeSkin.
@@ -65,23 +60,17 @@ ToSkinStateQueueTest >> testEnqueueInstallStateForThroughARequest [
 	self assert: q nextStates notNil.
 	self assert: q nextStates size isZero.
 	sk := ToRawSkin new.
-	e defaultSkin: sk.
-	" the default skin is set "
-	self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
-	e skinManager uninstallSkinIn: e.
-	" but not installed for now "
-	self
-		deny: (e skinManager installedSkin)
-		identicalTo: sk.
-	e skinManager installSkin: sk in: e.
-	" on enqueued, the state requests a next pulse and the queue is emptied "
-	self assert: q nextStates size equals: 0.
-	" the skin should be installed now because the skin management event handler 
-	reacts to a ToSkinInstallStateRequest by installing the skin 
-	(see #ToSkinManagementEventHandler>>skinInstallStateRequest:)"
-	self
-		assert: (e skinManager installedSkin)
-		identicalTo: sk
+	
+	space deferAndSettle: [
+		e defaultSkin: sk.
+		self assert: (e skinManager skinToInstallIn: e) identicalTo: sk.
+		e skinManager uninstallSkinIn: e.
+		uninstalled := e skinManager installedSkin.
+		e skinManager installSkin: sk in: e.
+		installed := e skinManager installedSkin ].
+		
+	self deny: uninstalled identicalTo: sk.
+	self assert: installed identicalTo: sk
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/ToSkinnablePropertySlotTest.class.st
+++ b/src/Toplo-Tests/ToSkinnablePropertySlotTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToSkinnablePropertySlotTest is a test class for testing the behavior of ToSkinnablePropertySlot
-"
 Class {
 	#name : #ToSkinnablePropertySlotTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -12,12 +9,7 @@ ToSkinnablePropertySlotTest >> testNew [
 
 	| e |
 	e := ToElementWithSkinnablePropertiesForTest new.
-	" -> 1 requestSkin "
-	space root addChild: e.
-	" -> 1 skin install : the skin is given by the theme. initializing the theme implies 1 requestNewSkin "
-	" -> toThemeChanged : -> 1 requestSkin "
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager installedSkin isUnknownSkin.
 	self assert: e skinStateQueueApplicationCount equals: 1
 ]
@@ -28,15 +20,12 @@ ToSkinnablePropertySlotTest >> testWriteTo [
 	| e |
 	e := ToElementWithSkinnablePropertiesForTest new.
 	self assert: e backgroundValue isTransparent.
-	" 1 requestSkin (postponed )"
-	e backgroundValue: Color blue.
+
+	space deferAndSettle: [
+		e backgroundValue: Color blue.
+		space root addChild: e ].
 	self assert: e backgroundValue paint color equals: Color blue.
 	self assert: e background paint color equals: Color blue.
-	" + 2 requestSkin (#onAddedToSceneGraph is sent 2 times)"
-	space root addChild: e.
-	" + 2 because of the theme installation "
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
 	self assert: e skinInstalledCount equals: 1.
 	self assert: e skinStateQueueApplicationCount equals: 1
 ]
@@ -46,17 +35,11 @@ ToSkinnablePropertySlotTest >> testWriteTo2 [
 
 	| e |
 	e := ToElementWithSkinnablePropertiesForTest new.
-	" + 1 requestSkin "
-	e backgroundValue: Color blue.
-	" + 2 requestSkin (#onAddedToSceneGraph is sent 2 times)"
-	space root addChild: e.
-
-	self assert: e border isTransparent.
-	" + 1 requestSkin "
-	e borderValue: Color red.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
-	" this is the second skin request since the first is automatically done when added in space "
+	space deferAndSettle: [
+		e backgroundValue: Color blue.
+		space root addChild: e.
+		self assert: e border isTransparent.
+		e borderValue: Color red ].
 	self assert: e border paint color equals: Color red.
 	self assert: e skinInstalledCount equals: 2
 ]
@@ -68,47 +51,25 @@ ToSkinnablePropertySlotTest >> testWriteTo4 [
 	e := ToElementWithSkinnablePropertiesForTest new.
 
 	self deny: e skinManager newSkinRequested.
-	" + 1 requestSkin "
-	e backgroundValue: Color blue.
-	" + 1 requestSkin "
-	e borderValue: Color red.
-	" + 2 requestSkin "
-	self assert: e skinInstalledCount equals: 0.
-	space root addChild: e.
+
+	space deferAndSettle: [
+		e backgroundValue: Color blue.
+		e borderValue: Color red.
+		self assert: e skinInstalledCount equals: 0.
+		space root addChild: e ].
 	self assert: e skinInstalledCount equals: 1.
 
-	e backgroundValue: Color blue.
-	self assert: e skinInstalledCount equals: 1.
-
-	space applyAllSkinInstallers.
-	self assert: e skinInstalledCount equals: 2.
-
+	space deferAndSettle: [ e backgroundValue: Color blue ].
 	self assert: e skinInstalledCount equals: 2.
 	self assert: e skinStateQueueApplicationCount equals: 3.
 	self deny: e skinManager newSkinRequested.
 
-	e backgroundValue: Color blue.
-
-	" background change -> new skin installer"
-	e borderValue: Color red.
-	" border change -> but no new skin installer because there is already one"
-	self assert: e skinManager newSkinRequested.
-	self assert: e skinStateQueueApplicationCount equals: 3.
-	space applyAllSkinInstallers.
-	" here states queue is applied two times: 1 for unsinstalling and 2 for installing "
+	space deferAndSettle: [
+		e backgroundValue: Color blue.
+		e borderValue: Color red ].
 	self assert: e skinStateQueueApplicationCount equals: 5.
-
-	space applyAllEnqueuedStates.
-
 	self assert: e skinInstalledCount equals: 3.
-	self assert: e skinStateQueueApplicationCount equals: 5.
 	self deny: e skinManager newSkinRequested.
-
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
-
-	self deny: e skinManager newSkinRequested.
-	" no new state "
 	self assert: e skinStateQueueApplicationCount equals: 5.
 	self assert: e skinInstalledCount equals: 3
 ]
@@ -118,12 +79,10 @@ ToSkinnablePropertySlotTest >> testWriteToWithSpaceAddChildBefore [
 
 	| e |
 	e := ToElementWithSkinnablePropertiesForTest new.
-	space root addChild: e.
-	e backgroundValue: Color blue.
-	e borderValue: Color red.
-
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
+	space deferAndSettle: [
+		e backgroundValue: Color blue.
+		e borderValue: Color red ].
 
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinInstalledCount equals: 2.

--- a/src/Toplo-Tests/ToSkinnablePropertyTest.class.st
+++ b/src/Toplo-Tests/ToSkinnablePropertyTest.class.st
@@ -25,9 +25,10 @@ ToSkinnablePropertyTest >> testRead [
 { #category : #tests }
 ToSkinnablePropertyTest >> testWriteTo [
 
-	| w prop writer reader |
+	| w prop writer reader newSkinRequestedAfter |
 	w := ToElement new.
-	BlSpace new root addChild: w.
+	space deferAndSettle: [
+		space root addChild: w ].
 	self deny: w skinManager newSkinRequested.
 	prop := ToSkinnableProperty new.
 	writer := [ :e :v | e background: v ].
@@ -38,8 +39,11 @@ ToSkinnablePropertyTest >> testWriteTo [
 	self assert: prop writer equals: writer.
 	self assert: prop reader equals: reader.
 	self assert: prop name equals: #background.
-	prop write: Color blue to: w.
-	self assert: w skinManager newSkinRequested.
+
+	space deferAndSettle: [
+		prop write: Color blue to: w.
+		newSkinRequestedAfter := w skinManager newSkinRequested ].
+	self assert: newSkinRequestedAfter.
 
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue.
@@ -49,10 +53,11 @@ ToSkinnablePropertyTest >> testWriteTo [
 { #category : #tests }
 ToSkinnablePropertyTest >> testWriteToWithDelegation [
 
-	| w prop writer reader |
+	| w prop writer reader newSkinRequestedAfter |
 	w := ToLabeledIcon new.
-	BlSpace new root addChild: w.
-	w label: (ToLabel text: '').
+	space deferAndSettle: [
+		space root addChild: w.
+		w label: (ToLabel text: '') ].
 	self assert: w label text asString equals: '' asRopedText asString.
 	prop := ToSkinnableProperty new.
 	writer := [ :e :v | e label text: v ].
@@ -60,15 +65,20 @@ ToSkinnablePropertyTest >> testWriteToWithDelegation [
 	prop writer: writer.
 	prop reader: reader.
 	prop name: #'label-text'.
-	w ensuredSkinManager requestNewSkinIn: w.
-	w skinManager installNewSkinIn: w.
+	space deferAndSettle: [
+		w ensuredSkinManager requestNewSkinIn: w ].
 	self deny: w skinManager newSkinRequested.
-	prop write: 'Hello' asRopedText to: w.
-	self assert: (w label text equals: 'Hello' asRopedText).
+
+	space deferAndSettle: [
+		prop write: 'Hello' asRopedText to: w.
+		newSkinRequestedAfter := w skinManager newSkinRequested ].
+	self
+		assert: w label text asString
+		equals: 'Hello'.
 	self
 		assert: (prop read: w) asString
-		equals: 'Hello' asRopedText asString.
-	self assert: w skinManager newSkinRequested
+		equals: 'Hello'.
+	self assert: newSkinRequestedAfter
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/ToSkinnableSlotTest.class.st
+++ b/src/Toplo-Tests/ToSkinnableSlotTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToSkinnableSlotTest is a test class for testing the behavior of ToSkinnableSlot
-"
 Class {
 	#name : #ToSkinnableSlotTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -12,12 +9,9 @@ ToSkinnableSlotTest >> testNew [
 
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
-	space root addChild: e.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e skinInstalledCount equals: 1.
 	self assert: e skinStateQueueApplicationCount equals: 1
-	
 ]
 
 { #category : #tests }
@@ -25,14 +19,11 @@ ToSkinnableSlotTest >> testWriteTo [
 
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
-	e child1: ToElement new.
-	space root addChild: e.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		e child1: ToElement new.
+		space root addChild: e ].
 	self assert: e skinInstalledCount equals: 1.
 	self assert: e skinStateQueueApplicationCount equals: 1
-
-	
 ]
 
 { #category : #tests }
@@ -40,15 +31,11 @@ ToSkinnableSlotTest >> testWriteTo2 [
 
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
-
-	e child1: ToElement new.
-	space root addChild: e.
-	e child2: ToElement new.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		e child1: ToElement new.
+		space root addChild: e.
+		e child2: ToElement new ].
 	self assert: e skinInstalledCount equals: 2
-
-	
 ]
 
 { #category : #tests }
@@ -56,15 +43,11 @@ ToSkinnableSlotTest >> testWriteTo3 [
 
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
-	e child1: ToElement new.
-	e child1: ToElement new.
-	space root addChild: e.
-	space applyAllSkinInstallers.
-
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		e child1: ToElement new.
+		e child1: ToElement new.
+		space root addChild: e ].
 	self assert: e skinInstalledCount equals: 1 
-
-	
 ]
 
 { #category : #tests }
@@ -73,36 +56,22 @@ ToSkinnableSlotTest >> testWriteTo4 [
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
 	self deny: e skinManager newSkinRequested.
-	e child1: ToElement new.
-	e child1: ToElement new.
-	space root addChild: e.
-	space applyAllSkinInstallers.
 
-	e child1: ToElement new.
-	" because of the child1: "
-
-	self assert: e skinInstalledCount equals: 1.
-	self assert: e skinManager newSkinRequested.
-
-	space applyAllSkinInstallers.
+	space deferAndSettle: [
+		e child1: ToElement new.
+		e child1: ToElement new.
+		space root addChild: e .
+		e child1: ToElement new ].
 	self assert: e skinInstalledCount equals: 2.
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinStateQueueApplicationCount equals: 3.
 
-	e child1: ToElement new.
-	e child1: ToElement new.
-
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
-
+	space deferAndSettle: [
+		e child1: ToElement new.
+		e child1: ToElement new ].
 	self assert: e skinInstalledCount equals: 3.
 	self assert: e skinStateQueueApplicationCount equals: 5.
 	self deny: e skinManager newSkinRequested.
-
-	space applyAllSkinInstallers.
-
-	self deny: e skinManager newSkinRequested.
-	" no new state enqueued "
 	self assert: e skinStateQueueApplicationCount equals: 5.
 	self assert: e skinInstalledCount equals: 3
 ]
@@ -112,12 +81,8 @@ ToSkinnableSlotTest >> testWriteToWithSpaceAddChildBefore [
 
 	| e |
 	e := ToElementWithSkinnableSlotsForTest new.
-	space root addChild: e.
-
-	e child1: ToElement new.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		space root addChild: e .
+		e child1: ToElement new ].
 	self assert: e skinInstalledCount equals: 2 
-
-	
 ]

--- a/src/Toplo-Tests/ToSpacePhasesManagerTest.class.st
+++ b/src/Toplo-Tests/ToSpacePhasesManagerTest.class.st
@@ -7,6 +7,13 @@ Class {
 	#category : #'Toplo-Tests-Core-SpaceFrame'
 }
 
+{ #category : #running }
+ToSpacePhasesManagerTest >> setUp [
+
+	super setUp.
+	space host stop
+]
+
 { #category : #tests }
 ToSpacePhasesManagerTest >> testApplyAllConfigurationsIn [
 
@@ -126,13 +133,7 @@ ToSpacePhasesManagerTest >> testNeedSkinInstallPass [
 	self assert: space phasesManager needSkinInstallPass.
 	space applyAllSkinInstallers.
 	" all skin installers should have been applied "
-	self deny: space phasesManager needSkinInstallPass.
-
-	
-
-
-
-	
+	self deny: space phasesManager needSkinInstallPass
 ]
 
 { #category : #tests }
@@ -158,12 +159,7 @@ ToSpacePhasesManagerTest >> testNeedSkinStateApplicationPass [
 	self deny: space phasesManager needSkinInstallPass.
 	e addStamp: #stamp.
 	self assert: space phasesManager needSkinInstallPass.
-	self deny: space phasesManager needSkinStateApplicationPass.
-
-
-
-
-	
+	self deny: space phasesManager needSkinStateApplicationPass
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/ToSpaceRootSkinTest.class.st
+++ b/src/Toplo-Tests/ToSpaceRootSkinTest.class.st
@@ -11,12 +11,15 @@ Class {
 ToSpaceRootSkinTest >> testInstallSkinEvent [
 	" test that a ToSpaceRootSkin is installed as soon a the space skin related phases are installed "
 
-	| e  |
-	space := BlSpace new.
+	| e isTransparent paintColor tokenVal |
 	e := ToElement new.
 	e defaultSkin: ToBackgroundColorSkinForTest new.
-	space root addChild: e.
-	self installNewSkinNowIn: e.
-	self deny: e background isTransparent.
-	self assert: e background paint color equals: (e valueOfTokenNamed: #'background-color')
+	space deferAndSettle: [
+		space root addChild: e.
+		self installNewSkinNowIn: e.
+		isTransparent := e background isTransparent.
+		paintColor := e background paint color.
+		tokenVal := e valueOfTokenNamed: #'background-color' ].
+	self deny: isTransparent.
+	self assert: paintColor equals: tokenVal
 ]

--- a/src/Toplo-Tests/ToSpaceSkinStateApplicationPhaseTest.class.st
+++ b/src/Toplo-Tests/ToSpaceSkinStateApplicationPhaseTest.class.st
@@ -8,6 +8,7 @@ Class {
 ToSpaceSkinStateApplicationPhaseTest >> testStartSkinPhases [
 
 	" before the element is added in space, its space frame phases remain unchanged "
+	space checkToploPhases.
 	self assert: (space frame phases anySatisfy: [ :p |
 			 p isKindOf: ToSpaceSkinInstallerPhase ]).
 	self assert: (space frame phases anySatisfy: [ :p |
@@ -18,6 +19,7 @@ ToSpaceSkinStateApplicationPhaseTest >> testStartSkinPhases [
 ToSpaceSkinStateApplicationPhaseTest >> testStartStopSkinStatePhases [
 
 	| nb stopped |
+	space checkToploPhases.
 	nb := space frame phases size.
 	stopped := false.
 	space addEventHandlerOn: ToSpacePhasesStopped doOnce: [

--- a/src/Toplo-Tests/ToStyleSheetApplicationTest.class.st
+++ b/src/Toplo-Tests/ToStyleSheetApplicationTest.class.st
@@ -57,35 +57,40 @@ ToStyleSheetApplicationTest >> testButtonLabelSkin0 [
 				with: [ :e | e valueOfTokenNamed: #'color-error-pressed' ] ].
 
 	button := ToButton new.
-	space toTheme: theme.
-	space root addChild: button.
-	button styleSheet: styleSheet.
 	label := (ToLabel text: 'Default') defaultSkin: nil.
 	label addStamp: #'button-label'.
 	button label: label.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: button.
+		button styleSheet: styleSheet].
 	labelSkin := ToBeeSkin new.
 	self assert: (button hasStamp: #danger) not.
 	self assert: (button label hasStamp: #'button-label').
+
 	writers := theme applicableListenersFor: button label.
 	" writers should be empty since the label rule expect the button 
 	to be of class #danger and the label to be with style class #'button-label'"
 	self assert: writers isEmpty.
-	button addAllStamps: #( #button #danger ).
-	button applyConfiguration.
+
+	space deferAndSettle: [
+		button addAllStamps: #( #button #danger ).
+		button applyConfiguration ].
 	writers := theme applicableListenersFor: button label.
 	self assert: writers size equals: 4.
 
-	labelSkin skinEventListeners: writers.
-	button label defaultSkin: labelSkin.
-	button label skinManager installNewSkinIn: button label.
+	space deferAndSettle: [
+		labelSkin skinEventListeners: writers.
+		button label defaultSkin: labelSkin.
+		button label skinManager installNewSkinIn: button label ].
 	attributes := button label text attributesAt: 1.
 	self assert: attributes notEmpty.
+
 	foregroundAttr := attributes
-		                  detect: [ :eachAttribute |
-		                  eachAttribute isKindOf: BlTextForegroundAttribute ]
-		                  ifNone: [
-			                  self fail:
-				                  'should have a foreground attribute (toTheme colorError)' ].
+		detect: [ :eachAttribute |
+			eachAttribute isKindOf: BlTextForegroundAttribute ]
+		ifNone: [
+			self fail: 'should have a foreground attribute (toTheme colorError)' ].
 	self
 		assert: foregroundAttr paint
 		equals: (button valueOfTokenNamed: #'color-error')
@@ -95,6 +100,7 @@ ToStyleSheetApplicationTest >> testButtonLabelSkin0 [
 ToStyleSheetApplicationTest >> testButtonSkin0 [
 
 	| button skin labelSkin attributes foregroundAttr writers label nb |
+
 	" default button rule "
 	styleSheet
 		select: (ToStampSelector new addStamp: #button)
@@ -155,18 +161,21 @@ ToStyleSheetApplicationTest >> testButtonSkin0 [
 				with: [ :e | e valueOfTokenNamed: #'color-error-pressed' ] ].
 
 	button := ToButton new.
-	space toTheme: theme.
-	space root addChild: button.
-	button addStamp: #button.
-	button styleSheet: styleSheet.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: button.
+		button addStamp: #button.
+		button styleSheet: styleSheet ].
 	writers := theme applicableListenersFor: button.
 	self assert: writers size equals: 5.
+
 	skin := ToBeeSkin new.
 	skin skinEventListeners: writers.
-	button defaultSkin: nil.
-	"self assert: button skinManager installedSkin isNil."
-	button defaultSkin: skin.
-	button skinManager installNewSkinIn: button.
+	space deferAndSettle: [
+		button defaultSkin: nil.
+		"self assert: button skinManager installedSkin isNil."
+		button defaultSkin: skin.
+		button skinManager installNewSkinIn: button ].
 	self assert: button border width equals: 1.
 	self assert: button border paint isColorPaint.
 	self
@@ -175,31 +184,34 @@ ToStyleSheetApplicationTest >> testButtonSkin0 [
 
 	label := ToLabel text: 'Default'.
 	label defaultSkin: nil.
-	button label: label.
+	space deferAndSettle: [ button label: label ].
 	labelSkin := ToStyleSheetSkin new.
 	writers := theme applicableListenersFor: button label.
 	nb := writers size.
 	self assert: nb equals: 0.
+
 	button label addStamp: #'button-label'.
 	writers := theme applicableListenersFor: button label.
 	" should be empty since the label rule expect the button to be of class #danger "
 	self assert: writers size equals: nb.
+
 	button addAllStamps: #( #button #danger ).
 	button applyConfiguration.
 	writers := theme applicableListenersFor: button label.
 	self assert: writers size equals: nb + 4.
 
 	labelSkin skinEventListeners: writers.
-	label defaultSkin: labelSkin.
-	label skinManager installNewSkinIn: label.
+	space deferAndSettle: [
+		label defaultSkin: labelSkin.
+		label skinManager installNewSkinIn: label ].
 	attributes := button label text attributesAt: 1.
 	self assert: attributes notEmpty.
+
 	foregroundAttr := attributes
-		                  detect: [ :eachAttribute |
-		                  eachAttribute isKindOf: BlTextForegroundAttribute ]
-		                  ifNone: [
-			                  self fail:
-				                  'should have a foreground attribute (toTheme colorError)' ].
+		detect: [ :eachAttribute |
+			eachAttribute isKindOf: BlTextForegroundAttribute ]
+		ifNone: [
+			self fail: 'should have a foreground attribute (toTheme colorError)' ].
 	self
 		assert: foregroundAttr paint
 		equals: (button label valueOfTokenNamed: #'color-error')
@@ -209,6 +221,7 @@ ToStyleSheetApplicationTest >> testButtonSkin0 [
 ToStyleSheetApplicationTest >> testButtonSkinWithInterspace [
 
 	| elem writers skin interspaceProp layoutProp |
+
 	interspaceProp := ToPseudoProperty
 		                  name: #'layout-interspace'
 		                  reader: [ :e | e layout startInterspace ]
@@ -223,17 +236,20 @@ ToStyleSheetApplicationTest >> testButtonSkinWithInterspace [
 			sr write: interspaceProp with: 10 ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 0.
+
 	elem addStamp: #button.
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 2.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [
+		elem defaultSkin: skin.
+		elem skinManager installNewSkinIn: elem ].
 	self assert: (elem layout isKindOf: BlLinearLayout).
 	self assert: elem layout interspace equals: 10
 ]
@@ -248,6 +264,7 @@ ToStyleSheetApplicationTest >> testEmptyStyleSheet [
 ToStyleSheetApplicationTest >> testSkinWith2SkinEventActionOnSameSkinEventEvent [
 
 	| elem listeners skin |
+
 	" here the border should be blue because only the last one is applied (for the same event) "
 	styleSheet select: (ToIdSelector new id: #a) style: [ :sr |
 		sr
@@ -258,15 +275,17 @@ ToStyleSheetApplicationTest >> testSkinWith2SkinEventActionOnSameSkinEventEvent 
 			do: [ :e :evt | e border: (BlBorder paint: Color blue width: 1) ] ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
 	elem id: #a.
+	space deferAndSettle: [ space root addChild: elem ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: listeners.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [
+		elem defaultSkin: skin.
+		elem skinManager installNewSkinIn: elem ].
 	self assert: elem border width equals: 1.
 	self assert: elem border paint isColorPaint.
 	self assert: elem border paint color equals: Color blue
@@ -282,15 +301,18 @@ ToStyleSheetApplicationTest >> testSkinWithAnUniversalRule [
 			when: ToInstallSkinEvent
 			write: (ToFeatureProperty new name: #background)
 			with: Color red ].
+
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [
+		elem defaultSkin: skin.
+		elem skinManager installNewSkinIn: elem ].
 	self assert: elem background paint color equals: Color red
 ]
 
@@ -309,10 +331,9 @@ ToStyleSheetApplicationTest >> testSkinWithChildRule [
 				write: (ToFeatureProperty new name: #border)
 				with: (BlBorder paint: Color red width: 3) ].
 
-
 	parent := ToElement new addStamp: #parent.
-	space root addChild: parent.
 	parent styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: parent ].
 	child := ToElement new id: #child.
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 0.
@@ -320,12 +341,13 @@ ToStyleSheetApplicationTest >> testSkinWithChildRule [
 	parent addChild: child.
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-	parent skinManager installNewSkinIn: parent.
-	child skinManager installNewSkinIn: child.
-
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		parent skinManager installNewSkinIn: parent.
+		child skinManager installNewSkinIn: child ].
 	self assert: child border width equals: 3.
 	self assert: child border paint isColorPaint.
 	self assert: child border paint color equals: Color red
@@ -348,22 +370,25 @@ ToStyleSheetApplicationTest >> testSkinWithChildRule2 [
 				with: (BlBorder paint: Color red width: 3) ].
 
 	parent := ToElement new addStamp: #parent.
-	space root addChild: parent.
 	parent styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: parent ].
 	subParent := ToElement new.
 	child := ToElement new id: #child.
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 0.
 
-	parent addChild: subParent.
-	subParent addChild: child.
+	space deferAndSettle: [
+		parent addChild: subParent.
+		subParent addChild: child ].
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-	parent skinManager installNewSkinIn: parent.
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		parent skinManager installNewSkinIn: parent.
+		child skinManager installNewSkinIn: child ].
 	self assert: child border width equals: 3.
 	self assert: child border paint isColorPaint.
 	self assert: child border paint color equals: Color red
@@ -380,17 +405,18 @@ ToStyleSheetApplicationTest >> testSkinWithIdRule [
 			with: (BlBorder paint: Color red width: 3) ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 0.
-	elem id: #a.
+
+	space deferAndSettle: [ elem id: #a ].
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [ elem defaultSkin: skin ].
 	self assert: elem border width equals: 3.
 	self assert: elem border paint isColorPaint.
 	self assert: elem border paint color equals: Color red
@@ -405,17 +431,18 @@ ToStyleSheetApplicationTest >> testSkinWithSkinEventAction [
 		sr do: [ :e | e border: (BlBorder paint: Color red width: 3) ] ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 0.
-	elem id: #a.
+
+	space deferAndSettle: [ elem id: #a ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: listeners.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [ elem defaultSkin: skin ].
 	self assert: elem border width equals: 3.
 	self assert: elem border paint isColorPaint.
 	self assert: elem border paint color equals: Color red
@@ -432,17 +459,18 @@ ToStyleSheetApplicationTest >> testSkinWithSkinEventAction2 [
 			do: [ :e | e border: (BlBorder paint: Color red width: 3) ] ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 0.
-	elem id: #a.
+
+	space deferAndSettle: [ elem id: #a ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: listeners.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [ elem defaultSkin: skin ].
 	self assert: elem border width equals: 3.
 	self assert: elem border paint isColorPaint.
 	self assert: elem border paint color equals: Color red
@@ -463,17 +491,18 @@ ToStyleSheetApplicationTest >> testSkinWithSkinEventActionMixedWithWriter [
 			do: [ :e | e border: (BlBorder paint: Color red width: 3) ] ].
 
 	elem := ToElement new.
-	space root addChild: elem.
 	elem styleSheet: styleSheet.
+	space deferAndSettle: [ space root addChild: elem ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 0.
-	elem id: #a.
+
+	space deferAndSettle: [ elem id: #a ].
 	listeners := theme applicableListenersFor: elem.
 	self assert: listeners size equals: 2.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: listeners.
-	elem defaultSkin: skin.
-	elem skinManager installNewSkinIn: elem.
+	space deferAndSettle: [ elem defaultSkin: skin ].
 	self assert: elem border width equals: 1.
 	self assert: elem border paint isColorPaint.
 	self assert: elem border paint color equals: Color blue
@@ -497,15 +526,16 @@ ToStyleSheetApplicationTest >> testStyleSheetStyle0 [
 
 	button := ToElement new.
 	button styleSheet: styleSheet.
-
 	button addStamp: #button.
-	space root addChild: button.
+	space deferAndSettle: [ space root addChild: button ].
 	writers := theme applicableListenersFor: button.
 	self assert: writers size equals: 2.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	button defaultSkin: skin.
-	button skinManager installNewSkinIn: button.
+	space deferAndSettle: [
+		button defaultSkin: skin.
+		button skinManager installNewSkinIn: button ].
 	self assert: button background paint isColorPaint.
 	self assert: button background paint color equals: Color black
 ]
@@ -514,7 +544,6 @@ ToStyleSheetApplicationTest >> testStyleSheetStyle0 [
 ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules0 [
 
 	| button skin writers |
-
 	styleSheet select: #button asStampSelector style: [ :sr |
 		sr select: #danger asStampSelector style: [
 			sr write: (styleSheet property: #background) with: Color red.
@@ -533,37 +562,37 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules0 [
 			with: [ :e | Color yellow ] ].
 
 	button := ToElement new.
-	space root addChild: button.
-	button styleSheet: styleSheet.
+	space deferAndSettle: [
+		space root addChild: button.
+		button styleSheet: styleSheet.
+		button addStamp: #button ].
 
-	button addStamp: #button.
 	writers := theme applicableListenersFor: button.
 	self assert: writers size equals: 2.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	button defaultSkin: skin.
-	button skinManager installNewSkinIn: button.
+	space deferAndSettle: [ button defaultSkin: skin ].
+	"button skinManager installNewSkinIn: button."
 	self assert: button background paint isColorPaint.
 	self assert: button background paint color equals: Color black.
 
-	button disabled: true.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ button disabled: true ].
 	self assert: button background paint isColorPaint.
 	self assert: button background paint color equals: Color yellow.
 
-	button disabled: false.
-	button addStamp: #danger.
+	space deferAndSettle: [
+		button disabled: false.
+		button addStamp: #danger ].
 	writers := theme applicableListenersFor: button.
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	button defaultSkin: skin.
-	button skinManager installNewSkinIn: button.
-
+	space deferAndSettle: [ button defaultSkin: skin ].
+	"button skinManager installNewSkinIn: button."
 	self assert: button background paint isColorPaint.
 	self assert: button background paint color equals: Color red.
 
-	button disabled: true.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ button disabled: true ].
 	self assert: button background paint isColorPaint.
 	self
 		assert: button background paint color
@@ -576,7 +605,7 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules1 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addStamp: #elem.
-	space root addChild: elem.
+	space deferAndSettle: [ space root addChild: elem ].
 
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
@@ -590,9 +619,10 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules1 [
 				write: (styleSheet property: #background)
 				with: [ :e | Color red ] ] ].
 
-	elem addChild: child.
-	child addChild: childchild1.
-	child addChild: childchild2.
+	space deferAndSettle: [
+		elem addChild: child.
+		child addChild: childchild1.
+		child addChild: childchild2 ].
 
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 0.
@@ -600,13 +630,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules1 [
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -617,17 +648,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules2 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addStamp: #elem.
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
-
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet
@@ -638,21 +667,20 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules2 [
 					write: (styleSheet property: #background)
 					with: [ :e | Color red ] ] ].
 
-
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -663,17 +691,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules22 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addAllStamps: #( elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
-
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet
@@ -684,21 +710,20 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules22 [
 					write: (styleSheet property: #background)
 					with: [ :e | Color red ] ] ].
 
-
 	writers := theme applicableListenersFor: elem.
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-	child skinManager installNewSkinIn: child.
-
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -709,16 +734,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules3 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addAllStamps: #( elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet
@@ -738,14 +762,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules3 [
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -756,16 +780,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules32 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addAllStamps: #( elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	styleSheet
 		select: (#child asStampSelector withParent: #elem asStampSelector)
@@ -785,14 +808,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules32 [
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -803,16 +826,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules33 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addAllStamps: #( elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	styleSheet
 		select: (#child asStampSelector withParent: #elem asStampSelector)
@@ -835,14 +857,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithSubRules33 [
 	self assert: writers size equals: 0.
 	writers := theme applicableListenersFor: childchild1.
 	self assert: writers size equals: 0.
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -853,16 +875,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules1 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addStamp: #elem.
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet select: #child asStampSelector style: [ :sr |
@@ -872,11 +893,12 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules1 [
 
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -887,16 +909,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules2 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addStamp: #elem.
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet
@@ -906,14 +927,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules2 [
 				write: (styleSheet property: #background)
 				with: [ :e | Color red ] ].
 
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -924,16 +945,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules3 [
 	| elem child childchild1 childchild2 skin writers |
 
 	elem := ToElement new addAllStamps: #( elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	" default button rule "
 	styleSheet
@@ -947,14 +967,14 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules3 [
 				write: (styleSheet property: #background)
 				with: [ :e | Color red ] ].
 
-
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red
 ]
@@ -965,16 +985,15 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules4 [
 	| elem child childchild1 childchild2 writers skin |
 
 	elem := ToElement new addAllStamps: #( #elem #red ).
-	space root addChild: elem.
-
 	child := ToElement new addStamp: #child.
 	childchild1 := ToElement new addStamp: #childchild1.
 	childchild2 := ToElement new addStamp: #childchild2.
-
 	elem styleSheet: styleSheet.
 	elem addChild: child.
 	child addChild: childchild1.
 	child addChild: childchild2.
+	space deferAndSettle: [
+		space root addChild: elem ].
 
 	styleSheet
 		select:
@@ -1000,22 +1019,26 @@ ToStyleSheetApplicationTest >> testStyleSheetStyleWithoutSubRules4 [
 
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color red.
 
-	elem addAllStamps: #( #elem #blue ).
-	elem removeStamp: #red.
+	space deferAndSettle: [
+		elem addAllStamps: #( #elem #blue ).
+		elem removeStamp: #red ].
 	writers := theme applicableListenersFor: child.
 	self assert: writers size equals: 1.
+
 	skin := ToStyleSheetSkin new.
 	skin skinEventListeners: writers.
-	child defaultSkin: skin.
-	child skinManager installNewSkinIn: child.
+	space deferAndSettle: [
+		child defaultSkin: skin.
+		child skinManager installNewSkinIn: child ].
 	self assert: child background paint isColorPaint.
 	self assert: child background paint color equals: Color blue
 ]

--- a/src/Toplo-Tests/ToStyleSheetApplicationTest2.class.st
+++ b/src/Toplo-Tests/ToStyleSheetApplicationTest2.class.st
@@ -21,7 +21,7 @@ ToStyleSheetApplicationTest2 >> testApplicationOnElement [
 
 	elem background: Color blue.
 	space toTheme: theme.
-	space root addChild: elem.
+	space deferAndSettle: [ space root addChild: elem ].
 	self assert: elem background paint color equals: Color red
 ]
 
@@ -48,10 +48,8 @@ ToStyleSheetApplicationTest2 >> testApplicationOnElementHovered [
 	elem position: 100 asPoint.
 	elem background: Color blue.
 	space toTheme: theme.
-	space root addChild: elem.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: elem  ].
 	self assert: elem background paint color equals: Color red.
-	BlSpace simulateMouseMoveInside: elem.
-	self waitTestingSpaces.
+	elem eventSimulator mouseMoveInside.
 	self assert: elem background paint color equals: Color yellow
 ]

--- a/src/Toplo-Tests/ToStyleSheetSkinTest.class.st
+++ b/src/Toplo-Tests/ToStyleSheetSkinTest.class.st
@@ -21,17 +21,18 @@ ToStyleSheetSkinTest >> setUp [
 
 	super setUp.
 	writeablePropertyIndex := ToPropertyIndex new.
-	writeablePropertyIndex addAllProperties: self defaultWritablePropertyList.
+	writeablePropertyIndex addAllProperties: self defaultWritablePropertyList
 ]
 
 { #category : #'test with accessors' }
 ToStyleSheetSkinTest >> testPropertyWriterOrderMatter [
 
-	| w skin layoutDirectionProp layoutProp layoutWriter directionWriter |
+	| w skin layoutDirectionProp layoutProp layoutWriter directionWriter error |
 	w := ToElement new.
 	space toTheme: ToStyleSheetTheme new.
-	space root addChild: w.
-	w layout: BlBasicLayout new.
+	space deferAndSettle: [
+		space root addChild: w.
+		w layout: BlBasicLayout new ].
 	skin := ToStyleSheetSkin new.
 	
 	layoutDirectionProp := self writablePropertyIndex propertyNamed:
@@ -48,33 +49,41 @@ ToStyleSheetSkinTest >> testPropertyWriterOrderMatter [
 		                value: BlLinearLayout new;
 		                yourself.
 
-	w defaultSkin: skin.
-	w ensuredSkinManager requestNewSkinIn: w.
+	space deferAndSettle: [
+		w defaultSkin: skin.
+		w ensuredSkinManager requestNewSkinIn: w.
 
-	" since applySkinInstaller will applyStyles "
-	self installNewSkinNowIn: w.
-	" force the event listeners in failing order (directionWriter before layoutWriter)"
-	skin skinEventListeners: {
-			directionWriter.
-			layoutWriter }.
+		" since applySkinInstaller will applyStyles "
+		self installNewSkinNowIn: w.
+		" force the event listeners in failing order (directionWriter before layoutWriter)"
+		skin skinEventListeners: {
+				directionWriter.
+				layoutWriter } ].
 
-	w skinManager skinStateQueue enqueueUninstallStateFor: w.
-	w skinManager skinStateQueue enqueueInstallStateFor: w.
-	" the installation will fail because the widget layout (not a BlLinearLayout) 
-	does not understand #direction:"
-	self
-		should: [ w skinManagerDo: [ :sm | sm applyEnqueuedStatesFor: w ] ]
-		raise: Error.
+	space deferAndSettle: [
+		w skinManager skinStateQueue enqueueUninstallStateFor: w.
+		w skinManager skinStateQueue enqueueInstallStateFor: w.
+		" the installation will fail because the widget layout (not a BlLinearLayout) 
+		does not understand #direction:"
+		[ w skinManagerDo: [ :sm | sm applyEnqueuedStatesFor: w ] ]
+			on: Error
+			do: [ :err | 
+				error := err.
+				w skinManager skinStateQueue resetStates ] ].
+
+	self assert: error notNil.
 	self deny: (w layout isKindOf: BlLinearLayout).
 
 	" Now change writers order and it should be ok "
-	skin skinEventListeners: {
-			layoutWriter.
-			directionWriter }.
+	space deferAndSettle: [
+		skin skinEventListeners: {
+				layoutWriter.
+				directionWriter }.
 
-	w skinManager skinStateQueue enqueueUninstallStateFor: w.
-	w skinManager skinStateQueue enqueueInstallStateFor: w.
-	w skinManagerDo: [ :sm | sm applyEnqueuedStatesFor: w ].
+		w skinManager skinStateQueue enqueueUninstallStateFor: w.
+		w skinManager skinStateQueue enqueueInstallStateFor: w.
+		w skinManagerDo: [ :sm | sm applyEnqueuedStatesFor: w ] ].
+
 	self assert: (w layout isKindOf: BlLinearLayout).
 	self assert: w layout direction isRightToLeft
 ]
@@ -84,20 +93,19 @@ ToStyleSheetSkinTest >> testSkinEventAction [
 
 	| w skin action |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	" skin installation initialize the event listeners collection "
-	self installNewSkinNowIn: w.
-	" now one can update the listeners collection "
 	action := ToSkinEventAction new action: [ :e |
 		          e background: Color blue ].
-	skin skinEventListeners: { action }.
+
+	space deferAndSettle: [
+		space root addChild: w.
+		self installNewSkinNowIn: w.
+		skin skinEventListeners: { action }.
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: skin skinEventListeners size equals: 1.
 	self assert: skin skinEventListeners first identicalTo: action.
-
-	" a ToInstallSkinEvent to force the running of the action "
-	w dispatchEvent: ToInstallSkinEvent new.
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue
 ]
@@ -107,7 +115,6 @@ ToStyleSheetSkinTest >> testSkinEventActionMixedWithWriter [
 
 	| w skin action prop propWriter |
 	w := ToElement new.
-	space root addChild: w.
 	action := ToSkinEventAction new action: [ :e |
 		          e background: Color red ].
 	prop := self writablePropertyIndex propertyNamed: #background.
@@ -117,19 +124,19 @@ ToStyleSheetSkinTest >> testSkinEventActionMixedWithWriter [
 		              yourself.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	w skinManager installNewSkinIn: w.
 
-	" SkinEventAction instances must be before all PropertyWriter instances. 
-	This must be ensured by the skin building procedure"
-	skin skinEventListeners: {
-			action.
-			propWriter }.
-	w dispatchEvent: ToInstallSkinEvent new.
+	space deferAndSettle: [
+		space root addChild: w.
+		" SkinEventAction instances must be before all PropertyWriter instances. 
+		This must be ensured by the skin building procedure"
+		skin skinEventListeners: {
+				action.
+				propWriter }.
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: skin skinEventListeners size equals: 2.
 	self assert: skin skinEventListeners first identicalTo: action.
 	self assert: skin skinEventListeners second identicalTo: propWriter.
-	
-	
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue
 ]
@@ -139,7 +146,6 @@ ToStyleSheetSkinTest >> testSkinEventListeners [
 
 	| w skin prop propWriter |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	prop := self writablePropertyIndex propertyNamed: #background.
 	propWriter := ToPropertyWriter new
@@ -147,13 +153,14 @@ ToStyleSheetSkinTest >> testSkinEventListeners [
 		              value: Color blue;
 		              yourself.
 	w defaultSkin: skin.
-	w skinManager installNewSkinIn: w.
 
-	skin skinEventListeners: { propWriter }.
+	space deferAndSettle: [
+		space root addChild: w.
+		skin skinEventListeners: { propWriter }.
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: skin skinEventListeners size equals: 1.
 	self assert: skin skinEventListeners first identicalTo: propWriter.
-	w dispatchEvent: ToInstallSkinEvent new.
-
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue
 ]
@@ -163,43 +170,45 @@ ToStyleSheetSkinTest >> testSupplementWriter [
 
 	| w skin backgroundProp borderProp borderBuilder |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	w skinManager installNewSkinIn: w.
 
 	borderBuilder := BlBorderBuilder new.
 	backgroundProp := self writablePropertyIndex propertyNamed:
 		                  #background.
 	borderProp := self writablePropertyIndex propertyNamed: #border.
-	skin skinEventListeners: {
-			(ToPropertyWriter new
-				 eventClass: ToInstallSkinEvent;
-				 property: backgroundProp;
-				 value: Color blue;
-				 yourself).
-			(ToPropertyWriter new
-				 property: borderProp;
-				 value: [ :e | Color yellow ];
-				 yourself).
-			(ToPropertyWriter new
-				 eventClass: ToInstallSkinEvent;
-				 property: borderProp;
-				 value: [ :e |
-					 borderBuilder
-						 paint: Color red;
-						 build ] yourself).
-			(ToPropertyWriter new
-				 supplement: true;
-				 eventClass: ToInstallSkinEvent;
-				 property: borderProp;
-				 value: [ :e |
-					 borderBuilder
-						 paint: Color black;
-						 dashArray: #( 4 5 );
-						 build ] yourself) }.
 
-	w dispatchEvent: ToInstallSkinEvent new.
+	space deferAndSettle: [
+		space root addChild: w.
+		skin skinEventListeners: {
+				(ToPropertyWriter new
+					 eventClass: ToInstallSkinEvent;
+					 property: backgroundProp;
+					 value: Color blue;
+					 yourself).
+				(ToPropertyWriter new
+					 property: borderProp;
+					 value: [ :e | Color yellow ];
+					 yourself).
+				(ToPropertyWriter new
+					 eventClass: ToInstallSkinEvent;
+					 property: borderProp;
+					 value: [ :e |
+						 borderBuilder
+							 paint: Color red;
+							 build ] yourself).
+				(ToPropertyWriter new
+					 supplement: true;
+					 eventClass: ToInstallSkinEvent;
+					 property: borderProp;
+					 value: [ :e |
+						 borderBuilder
+							 paint: Color black;
+							 dashArray: #( 4 5 );
+							 build ] yourself) }.
+
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue.
 	self assert: w border paint color equals: Color black.
@@ -209,48 +218,52 @@ ToStyleSheetSkinTest >> testSupplementWriter [
 { #category : #'test with accessors' }
 ToStyleSheetSkinTest >> testWithAnimationOn2EventClasses [
 
-	| w skin prop animation |
+	| w skin prop animation finished |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	w ensuredSkinManager requestNewSkinIn: w.
-	w skinManager installNewSkinIn: w.
 
-	animation := ToPropertyColorTransitionAnimation new.
+	animation := ToPropertyBackgroundColorTransitionAnimation new.
 	prop := self writablePropertyIndex propertyNamed: #background.
 
-	skin skinEventListeners: {
-			(ToPropertyWriter new
-				 property: prop;
-				 eventClass: ToInstallSkinEvent;
-				 value: Color white;
-				 yourself).
-			(ToPropertyWriter new
-				 property: prop;
-				 eventClass: ToHoveredSkinEvent;
-				 value: Color black;
-				 animation: animation;
-				 yourself).
-			(ToPropertyWriter new
-				 property: prop;
-				 eventClass: ToLeftSkinEvent;
-				 value: Color white;
-				 animation: animation;
-				 yourself) }.
+	space deferAndSettle: [
+		space root addChild: w.
+		w ensuredSkinManager requestNewSkinIn: w.
+		skin skinEventListeners: {
+				(ToPropertyWriter new
+					 property: prop;
+					 eventClass: ToInstallSkinEvent;
+					 value: Color white;
+					 yourself).
+				(ToPropertyWriter new
+					 property: prop;
+					 eventClass: ToHoveredSkinEvent;
+					 value: Color black;
+					 animation: animation;
+					 yourself).
+				(ToPropertyWriter new
+					 property: prop;
+					 eventClass: ToLeftSkinEvent;
+					 value: Color white;
+					 animation: animation;
+					 yourself) }.
 
-	w dispatchEvent: ToInstallSkinEvent new.
+		w dispatchEvent: ToInstallSkinEvent new ].
 
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color white.
 
-	w skinManager enqueueTransientState: ToHoveredSkinEvent new for: w.
-	animation onFinishedDo: [ :x |
+	finished := false.
+	space deferAndSettle: [
+		w skinManager enqueueTransientState: ToHoveredSkinEvent new for: w.
+		animation onFinishedDo: [ :x |
 			self assert: w background paint color equals: Color black.
-
 			w skinManager enqueueTransientState: ToLeftSkinEvent new for: w.
 			animation onFinishedDo: [ :xx |
-				self assert: w background paint color equals: Color white ] ]
+				self assert: w background paint color equals: Color white.
+				finished := true ] ] ].
+
+	space waitUntilTrue: [ finished ] forDuration: 2 seconds
 ]
 
 { #category : #'test with accessors' }
@@ -258,11 +271,12 @@ ToStyleSheetSkinTest >> testWithNoWriter [
 
 	| w skin paint |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
 	paint := w background paint.
-	w skinManager installNewSkinIn: w.
+
+	space deferAndSettle: [
+		space root addChild: w ].
 
 	self assert: w background paint equals: paint
 ]
@@ -272,24 +286,26 @@ ToStyleSheetSkinTest >> testWithTwoWriters [
 
 	| w skin backgroundProp borderProp |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	w skinManager installNewSkinIn: w.
 	
 	backgroundProp := self writablePropertyIndex propertyNamed:
 		                  #background.
 	borderProp := self writablePropertyIndex propertyNamed: #border.
-	skin skinEventListeners: {
-			(ToPropertyWriter new
-				 property: backgroundProp;
-				 value: Color blue;
-				 yourself).
-			(ToPropertyWriter new
-				 property: borderProp;
-				 value: Color yellow;
-				 yourself) }.
-	w dispatchEvent: ToInstallSkinEvent new.
+
+	space deferAndSettle: [
+		space root addChild: w.
+		skin skinEventListeners: {
+				(ToPropertyWriter new
+					 property: backgroundProp;
+					 value: Color blue;
+					 yourself).
+				(ToPropertyWriter new
+					 property: borderProp;
+					 value: Color yellow;
+					 yourself) }.
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue.
 	self assert: w border paint color equals: Color yellow
@@ -300,30 +316,32 @@ ToStyleSheetSkinTest >> testWithTwoWritersTwoEventClasses [
 
 	| w skin backgroundProp borderProp |
 	w := ToElement new.
-	space root addChild: w.
 	skin := ToStyleSheetSkin new.
 	w defaultSkin: skin.
-	w skinManager installNewSkinIn: w.
 	backgroundProp := self writablePropertyIndex propertyNamed:
 		                  #background.
 	borderProp := self writablePropertyIndex propertyNamed: #border.
-	skin skinEventListeners: {
-			(ToPropertyWriter new
-				 eventClass: ToInstallSkinEvent;
-				 property: backgroundProp;
-				 value: Color blue;
-				 yourself).
-			(ToPropertyWriter new
-				 eventClass: ToInstallSkinEvent;
-				 property: borderProp;
-				 value: Color yellow;
-				 yourself).
-			(ToPropertyWriter new
-				 eventClass: ToInstallSkinEvent;
-				 property: borderProp;
-				 value: Color red;
-				 yourself) }.
-	w dispatchEvent: ToInstallSkinEvent new.
+
+	space deferAndSettle: [
+		space root addChild: w.
+		skin skinEventListeners: {
+				(ToPropertyWriter new
+					 eventClass: ToInstallSkinEvent;
+					 property: backgroundProp;
+					 value: Color blue;
+					 yourself).
+				(ToPropertyWriter new
+					 eventClass: ToInstallSkinEvent;
+					 property: borderProp;
+					 value: Color yellow;
+					 yourself).
+				(ToPropertyWriter new
+					 eventClass: ToInstallSkinEvent;
+					 property: borderProp;
+					 value: Color red;
+					 yourself) }.
+		w dispatchEvent: ToInstallSkinEvent new ].
+
 	self assert: (w background isKindOf: BlPaintBackground).
 	self assert: w background paint color equals: Color blue.
 	self assert: w border paint color equals: Color red

--- a/src/Toplo-Tests/ToStyleSheetTest.class.st
+++ b/src/Toplo-Tests/ToStyleSheetTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToStyleSheetTest is a test class for testing the behavior of ToStyleSheet
-"
 Class {
 	#name : #ToStyleSheetTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -58,8 +55,7 @@ ToStyleSheetTest >> testMyOutskirts [
 	e outskirts: BlOutskirts inside.
 	e localTheme: theme.
 	e styleSheet: styleSheet.
-	space root addChild: e.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ space root addChild: e ].
 
 	writers := theme applicableWritersFor: e.
 	self assert: writers size equals: 1.
@@ -69,39 +65,47 @@ ToStyleSheetTest >> testMyOutskirts [
 { #category : #tests }
 ToStyleSheetTest >> testOnInstalledIn [
 
-	| sheet e child |
+	| sheet e child requested childRequested |
 	sheet := ToStyleSheet new.
 	e := ToElement new.
 	child := ToElement new.
 	e addChild: child.
-	space root addChild: e.
-	space applyAllSkinInstallers.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinManager installedSkin isThemeSkin.
 	self deny: child skinManager newSkinRequested.
 	self assert: child skinManager installedSkin isThemeSkin.
-	e styleSheet: sheet.
-	self assert: e skinManager newSkinRequested.
-	self assert: child skinManager newSkinRequested.
 
+	space deferAndSettle: [
+		e styleSheet: sheet.
+		requested := e skinManager newSkinRequested.
+		childRequested := child skinManager newSkinRequested ].
+		
+	self assert: requested.
+	self assert: childRequested
 ]
 
 { #category : #tests }
 ToStyleSheetTest >> testOnUninstalledIn [
 
-	| sheet e child |
+	| sheet e child requested childRequested |
 	sheet := ToStyleSheet new.
 	e := ToElement new.
 	child := ToElement new.
 	e addChild: child.
-	space root addChild: e.
-	e styleSheet: sheet.
-	space applyAllSkinInstallers.
+	space deferAndSettle: [
+		space root addChild: e.
+		e styleSheet: sheet ].
 	self deny: e skinManager newSkinRequested.
 	self deny: child skinManager newSkinRequested.
-	e styleSheet: nil.
-	self assert: e skinManager newSkinRequested.
-	self deny: child skinManager newSkinRequested
+
+	space deferAndSettle: [
+		e styleSheet: nil.
+		requested := e skinManager newSkinRequested.
+		childRequested := child skinManager newSkinRequested ].
+		
+	self assert: requested.
+	self deny: childRequested
 ]
 
 { #category : #'writable property tests' }
@@ -122,8 +126,7 @@ ToStyleSheetTest >> testOutskirts [
 	e outskirts: BlOutskirts inside.
 	e localTheme: theme.
 	e styleSheet: styleSheet.
-	space root addChild: e.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ space root addChild: e ].
 
 	writers := theme applicableWritersFor: e.
 	self assert: writers size equals: 1.

--- a/src/Toplo-Tests/ToTestCaseWithSpace.class.st
+++ b/src/Toplo-Tests/ToTestCaseWithSpace.class.st
@@ -1,13 +1,10 @@
 Class {
 	#name : #ToTestCaseWithSpace,
-	#superclass : #TestCase,
-	#instVars : [
-		'space'
-	],
+	#superclass : #BlSpaceTestCase,
 	#category : #'Toplo-Tests-Core'
 }
 
-{ #category : #'as yet unclassified' }
+{ #category : #'skin management' }
 ToTestCaseWithSpace >> installNewSkinNowIn: anElement [
 	" bypass the normal skinRequest/skinInstallation scheme"
 
@@ -15,16 +12,7 @@ ToTestCaseWithSpace >> installNewSkinNowIn: anElement [
 		Error signal:
 			'A non attached element can''t ask for an immediate skin change ' ].
 	anElement ensuredSkinManager requestNewSkinIn: anElement.
-	anElement skinManager newSkinRequested ifTrue: [ 
+	anElement skinManager newSkinRequested ifTrue: [
 		anElement skinManager installNewSkinIn: anElement ].
 	anElement requestSkinApplication
-]
-
-{ #category : #running }
-ToTestCaseWithSpace >> setUp [ 
-
-	super setUp.
-	space := BlSpace new.
-	space checkToploPhases 
-
 ]

--- a/src/Toplo-Tests/ToThemeTest.class.st
+++ b/src/Toplo-Tests/ToThemeTest.class.st
@@ -10,11 +10,10 @@ ToThemeTest >> testThemeChanged [
 	| e |
 	e := ToElement new.
 	e defaultSkin: ToRawSkinForThemeTest new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
-	space toTheme: ToRawDarkTheme new.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ space toTheme: ToRawDarkTheme new ].
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinManager installedSkin class identicalTo: ToRawSkinForThemeTest
 ]
@@ -25,12 +24,11 @@ ToThemeTest >> testThemeChangedWithStyleSheetTheme [
 	| e |
 	e := ToElement new.
 	e defaultSkin: ToRawSkinForThemeTest new.
-	space root addChild: e.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: e ].
 	self deny: e skinManager newSkinRequested.
 	self assert: (e skinManager installedSkin isKindOf: ToRawSkinForThemeTest).
-	space toTheme: ToBeeDarkTheme new.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ space toTheme: ToBeeDarkTheme new ].
 	self deny: e skinManager newSkinRequested.
 	self deny: (e skinManager installedSkin isKindOf: ToBeeSkin).
 	self assert: e skinManager installedSkin identicalTo: e defaultSkin
@@ -41,15 +39,13 @@ ToThemeTest >> testThemeChangedWithStyleSheetTheme2 [
 
 	| e |
 	e := ToButton new.
-	space root addChild: e.
-	e addStamp: #'primary'.
-	e labelText: 'Default button'.
-	self waitTestingSpaces.
-	space toTheme: ToBeeDarkTheme new.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: e.
+		e addStamp: #'primary'.
+		e labelText: 'Default button' .
+		space toTheme: ToBeeDarkTheme new ].
 	self deny: e skinManager newSkinRequested.
 	self assert: (e skinManager installedSkin isKindOf: ToBeeSkin)
-
 ]
 
 { #category : #tests }
@@ -57,18 +53,13 @@ ToThemeTest >> testThemeChangedWithStyleSheetTheme3 [
 
 	| e |
 	e := ToLabeledIcon new.
-	space toTheme: ToBeeDarkTheme new.
-	space root addChild: e.
-	e addStamp: #primary.
-	e labelText: 'Default button'.
+	space deferAndSettle: [
+		space toTheme: ToBeeDarkTheme new.
+		space root addChild: e.
+		e addStamp: #primary.
+		e labelText: 'Default button' ].
 	self assert: e skinManager installedSkin isThemeSkin.
-	" because of the token properties installation -> have a skin installer/uninstaller "
-	self assert: e skinManager newSkinRequested.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
 	self deny: e skinManager newSkinRequested.
 	self assert: e skinManager installedSkin isThemeSkin.
-	self applyAllEnqueuedStates.
-	self waitTestingSpaces.
 	self deny: e skinManager newSkinRequested
 ]

--- a/src/Toplo-Tests/ToTooltipWindowTest.class.st
+++ b/src/Toplo-Tests/ToTooltipWindowTest.class.st
@@ -8,55 +8,61 @@ Class {
 }
 
 { #category : #tests }
+ToTooltipWindowTest >> setUpTooltipWindow [
+
+	| element windowManager |
+	element := ToElement new.
+	element extent: 100 @ 100.
+	element tooltipBuilder: [ :win :request |
+		win root addChild: (ToLabel text: 'Tooltip content') ].
+
+	windowManager := element ensuredTooltipManager.
+	windowManager popupDelay: 10 milliSeconds.
+
+	space deferAndSettle: [ space root addChild: element ].
+
+	element eventSimulator mouseMoveInside.
+	space waitUntilTrue: [
+		windowManager currentWindow notNil and: [
+			windowManager currentWindow isOpened ] ].
+
+	^ windowManager currentWindow
+]
+
+{ #category : #tests }
 ToTooltipWindowTest >> testContent [
 
-	| e windowManager |
-	e := ToElement new extent: 100 @ 100.
-	e tooltipBuilder: [ :win :request |
-		win root addChild: (ToLabel text: 'Tooltip content') ].
-	windowManager := e ensuredTooltipManager.
-	self assert: (windowManager isKindOf: ToTooltipManager).
-	space root addChild: e.
-
-	BlSpace simulateMouseMoveInside: e.
-	self waitTestingSpaces.
-	900 milliSecond wait.
-	self waitTestingSpaces.
-
-	self assert:
-		(windowManager currentWindow root firstChild isKindOf: ToLabel).
+	| tooltipWindow |
+	tooltipWindow := self setUpTooltipWindow.
 	self
-		assert: windowManager currentWindow root firstChild text asString
-		equals: 'Tooltip content'.
-	^ windowManager currentWindow
+		assert: tooltipWindow root firstChild class
+		equals: ToLabel.
+	self
+		assert: tooltipWindow root firstChild text asString
+		equals: 'Tooltip content'
 ]
 
 { #category : #tests }
 ToTooltipWindowTest >> testCurrentWindow [
 
-	| window |
-	
-	window := self testContent.
-	self assert: window isOpened.
-	self assert: window notNil.
-	self assert: window isOpened.
-
+	| tooltipWindow |
+	tooltipWindow := self setUpTooltipWindow.
+	self assert: tooltipWindow notNil.
+	self assert: tooltipWindow isOpened
 ]
 
 { #category : #tests }
 ToTooltipWindowTest >> testDefaultElevation [
 
-	| window |
-	window := self testContent.
+	| tooltipWindow |
+	tooltipWindow := self setUpTooltipWindow.
 	self
-		assert: window  elevation elevation
-		equals: window  defaultElevation elevation
+		assert: tooltipWindow elevation elevation
+		equals: tooltipWindow defaultElevation elevation
 ]
 
 { #category : #tests }
 ToTooltipWindowTest >> testInitialize [
 
-	| w |
-	w := ToTooltipWindow new.
-	self deny: w hasManager
+	self deny: ToTooltipWindow new hasManager
 ]

--- a/src/Toplo-Tests/ToTransientStateTest.class.st
+++ b/src/Toplo-Tests/ToTransientStateTest.class.st
@@ -27,11 +27,10 @@ ToTransientStateTest >> testOnAppliedOn [
 
 	| e stateEvt state |
 	e := ToElement new.
-	space root addChild: e.
+	space deferAndSettle: [ space root addChild: e ].
 	state := ToTransientStateStub skinEvent: (stateEvt := ToHoveredSkinEvent new).
-	state applyOn: e fromQueue: nil.
+	space deferAndSettle: [ state applyOn: e fromQueue: nil ].
 	self assert: state applyCount equals: 1
-	
 ]
 
 { #category : #tests }

--- a/src/Toplo-Theme-Bee-Tests/ToBeeThemeTest.class.st
+++ b/src/Toplo-Theme-Bee-Tests/ToBeeThemeTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToBeeThemeTest is a test class for testing the behavior of ToBeeTheme
-"
 Class {
 	#name : #ToBeeThemeTest,
 	#superclass : #ToTestCaseWithSpace,
@@ -11,7 +8,7 @@ Class {
 ToBeeThemeTest >> setUp [ 
 
 	super setUp.
-	space toTheme: ToBeeTheme new.
+	space toTheme: ToBeeTheme new
 ]
 
 { #category : #tests }
@@ -19,9 +16,7 @@ ToBeeThemeTest >> testDefaultButtonSkin [
 
 	| button |
 	button := ToButton new.
-	space root addChild: button.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [ space root addChild: button ].
 
 	self assert: button border width equals: (button valueOfTokenNamed: #'line-width').
 	self assert: button border paint isColorPaint.
@@ -33,22 +28,19 @@ ToBeeThemeTest >> testSpaceRoot [
 
 	| theme e |
 	theme := ToStyleSheetTheme new.
-	space toTheme: theme.
 	e := ToElement new
 		     extent: 100 @ 100;
 		     position: 10 @ 10;
 		     addStamp: #machin;
 		     background: Color white.
-	space root addChild: e.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: e ].
 	self
 		assert: space root background paint color
 		equals: (space root valueOfTokenNamed: 'background-color').
 	theme := ToBeeDarkTheme new.
-	space toTheme: theme.
-	space applyAllSkinInstallers.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [ space toTheme: theme ].
 	self
 		assert: space root background paint color
 		equals: (space root valueOfTokenNamed: 'background-color')

--- a/src/Toplo-Widget-Album-Tests/ToAlbumSkinTest.class.st
+++ b/src/Toplo-Widget-Album-Tests/ToAlbumSkinTest.class.st
@@ -11,16 +11,18 @@ Class {
 ToAlbumSkinTest >> testFocusedSkinEvent [
 
 	| a focusCount |
-	a := ToAlbum new extent: 100 asPoint.
-	space root addChild: a.
+	a := ToAlbum new.
+	a extent: 100 asPoint.
 	self deny: a hasFocus.
 	focusCount := 0.
 	a
 		addEventHandlerOn: ToFocusedSkinEvent
 		do: [ :event | focusCount := focusCount + 1 ].
-	a requestFocus.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
+
+	space deferAndSettle: [ space root addChild: a ].
+	self assert: focusCount equals: 0.
+
+	space deferAndSettle: [ a requestFocus ].
 	self assert: focusCount equals: 1
 ]
 
@@ -30,21 +32,19 @@ ToAlbumSkinTest >> testUnfocusedSkinEvent [
 	| a1 a2 unfocusCount |
 	a1 := ToListElement new extent: 100 asPoint.
 	a2 := ToAlbum new extent: 100 asPoint.
-	space root addChild: a1.
-	space root addChild: a2.
+	space deferAndSettle: [ 
+		space root addChild: a1.
+		space root addChild: a2 ].
 	self deny: a1 isFocused.
 	self deny: a2 isFocused.
 	unfocusCount := 0.
 	a2
 		addEventHandlerOn: ToUnfocusedSkinEvent
 		do: [ :event | unfocusCount := unfocusCount + 1 ].
-	a2 requestFocus.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	a1 requestFocus.
-	self waitTestingSpaces.
+	space deferAndSettle: [ a2 requestFocus ].
+	"Must be in a separate block to allow skin state updates of the first focus change to be processed"
+	space deferAndSettle: [ a1 requestFocus ].
 	self assert: a1 isFocused.
 	self deny: a2 isFocused.
-	space applyAllSkinPhases.
 	self assert: unfocusCount equals: 1
 ]

--- a/src/Toplo-Widget-Album-Tests/ToLabelTest.class.st
+++ b/src/Toplo-Widget-Album-Tests/ToLabelTest.class.st
@@ -10,29 +10,25 @@ Class {
 { #category : #tests }
 ToLabelTest >> testBeMonoline [
 
-	| lab |
-	lab := ToLabel new.
-	lab text: 'A'.
+	| label |
+	label := ToLabel new.
+	label text: 'A'.
 	" monoline by default "
-	self assert: (lab innerElement isKindOf: ToLabelMonoLineInnerElement).
-	lab beMultiLine.
-	self assert: (lab innerElement isKindOf: ToLabelMultiLineInnerElement).
-	lab beMonoLine.
-	self assert: (lab innerElement isKindOf: ToLabelMonoLineInnerElement).
-
-	
-
+	self assert: (label innerElement isKindOf: ToLabelMonoLineInnerElement).
+	label beMultiLine.
+	self assert: (label innerElement isKindOf: ToLabelMultiLineInnerElement).
+	label beMonoLine.
+	self assert: (label innerElement isKindOf: ToLabelMonoLineInnerElement)
 ]
 
 { #category : #tests }
 ToLabelTest >> testBeMultiline [
 
-	| lab |
-	lab := ToLabel new.
-	lab text: 'A'.
-	lab beMultiLine.
-	self assert: (lab innerElement isKindOf: ToLabelMultiLineInnerElement).
-
+	| label |
+	label := ToLabel new.
+	label text: 'A'.
+	label beMultiLine.
+	self assert: (label innerElement isKindOf: ToLabelMultiLineInnerElement)
 ]
 
 { #category : #tests }
@@ -44,9 +40,10 @@ ToLabelTest >> testSkinUpdatedAfterTextChanged [
 
 	" declare a specific style sheet theme with one property to change the defont font size "
 	theme := ToStyleSheetTheme new.
-	theme styleSheet addWritableProperty: (ToPseudoProperty new
-			 name: #'text-attributes-with-builder';
-			 writer: [ :e :v | e text attributes: v attributes. e applyStyle ]).
+	theme styleSheet addWritableProperty:
+		(ToPseudoProperty new
+			name: #'text-attributes-with-builder';
+			writer: [ :e :v | e text attributes: v attributes. e applyStyle ]).
 
 	theme select: #HUGE asStampSelector style: [ :sr |
 		sr
@@ -56,53 +53,46 @@ ToLabelTest >> testSkinUpdatedAfterTextChanged [
 					defaultFontSize: hugeFontSize;
 					yourself ] ].
 
-	space toTheme: theme.
-	label := ToLabel text: 'Hello'.
-	space root addChild: label.
-
-	self waitTestingSpaces.
-	attributes := label text attributesAt: 1.
-
 	" The default stylesheet theme has no rule by default, so the default attributes is not installed"
+	label := ToLabel text: 'Hello'.
+	space deferAndSettle: [
+		space toTheme: theme.
+		space root addChild: label ].
+	attributes := label text attributesAt: 1.
 	self assert: attributes isEmpty.
+
 	"adding a stamp should renew the skin (and then take the stamp into account)"
-	label addStamp: #HUGE.
-
-	self waitTestingSpaces.
-	fontSizeAttr := label text iterator
-		                detectAttribute: [ :a |
-		                a isKindOf: BlFontSizeDefaultAttribute ]
-		                ifFound: [ :a | a ]
-		                ifNone: [
-		                self fail:
-			                'should have a BlFontSizeDefaultAttribute' ].
-
+	space deferAndSettle: [ label addStamp: #HUGE ].
+	fontSizeAttr :=
+		label text iterator
+			detectAttribute: [ :a | a isKindOf: BlFontSizeDefaultAttribute ]
+			ifFound: [ :a | a ]
+			ifNone: [
+				self fail: 'should have a BlFontSizeDefaultAttribute' ].
 	self assert: fontSizeAttr size equals: hugeFontSize.
+
 	" changing the text should renew the skin (and then take the stamp into account again)"
-	label text: 'Goodbye'.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ label text: 'Goodbye' ].
 	prevAttributes := attributes.
 	attributes := label text attributesAt: 1.
-	self assert: prevAttributes ~~ attributes.
-	fontSizeAttr := label text iterator
-		                detectAttribute: [ :a |
-		                a isKindOf: BlFontSizeDefaultAttribute ]
-		                ifFound: [ :a | a ]
-		                ifNone: [
-		                self fail:
-			                'should have a BlFontSizeDefaultAttribute' ].
+	self deny: prevAttributes identicalTo: attributes.
+	fontSizeAttr :=
+		label text iterator
+			detectAttribute: [ :a | a isKindOf: BlFontSizeDefaultAttribute ]
+			ifFound: [ :a | a ]
+			ifNone: [ self fail: 'should have a BlFontSizeDefaultAttribute' ].
 	self assert: fontSizeAttr size equals: hugeFontSize
 ]
 
 { #category : #tests }
 ToLabelTest >> testText [
 
-	| lab |
-	lab := ToLabel new.
-	self assert: lab text isEmpty.
-	lab text: 'A'.
-	self assert: (lab text isKindOf: BlRopedText).
-	self assert: lab text asString equals: 'A' 
+	| label |
+	label := ToLabel new.
+	self assert: label text isEmpty.
+	label text: 'A'.
+	self assert: (label text isKindOf: BlRopedText).
+	self assert: label text asString equals: 'A' 
 ]
 
 { #category : #tests }
@@ -114,42 +104,34 @@ ToLabelTest >> testTextChangePreserveAttributes2 [
 	hugeFontSize := 60.
 
 	label := ToLabel text: 'Hello'.
-	space root addChild: label.
-	space applyAllSkinPhases.
+	space deferAndSettle: [ space root addChild: label ].
 	attributes := label text attributesAt: 1.
 	" skin default attributes  "
 	self assert: attributes notEmpty.
 
-	label defaultFontSize: hugeFontSize.
-	fontSizeAttr := label text iterator
-		                detectAttribute: [ :a |
-		                a isKindOf: BlFontSizeDefaultAttribute ]
-		                ifFound: [ :a | a ]
-		                ifNone: [
-		                self fail:
-			                'should have a BlFontSizeDefaultAttribute' ].
+	space deferAndSettle: [ label defaultFontSize: hugeFontSize ].
+	fontSizeAttr :=
+		label text iterator
+			detectAttribute: [ :a | a isKindOf: BlFontSizeDefaultAttribute ]
+			ifFound: [ :a | a ]
+			ifNone: [ self fail: 'should have a BlFontSizeDefaultAttribute' ].
 	" remember that the skin drives the look so the font size is not applied here "
 	"self deny: fontSizeAttr size equals: hugeFontSize.
 	self
 		assert: fontSizeAttr size
 		equals: (label valueOfTokenNamed: #'font-size')."
-	space applyAllSkinPhases.
-	" changing the text should renew the skin (and then take the stamp into account again)"
-	label text: 'Goodbye'.
-	space applyAllSkinPhases.
 
+	" changing the text should renew the skin (and then take the stamp into account again)"
+	space deferAndSettle: [ label text: 'Goodbye' ].
 	self assert: label text asString equals: 'Goodbye'.
 	prevAttributes := attributes.
-
 	attributes := label text attributesAt: 1.
-	self assert: prevAttributes ~~ attributes.
-	fontSizeAttr := label text iterator
-		                detectAttribute: [ :a |
-		                a isKindOf: BlFontSizeDefaultAttribute ]
-		                ifFound: [ :a | a ]
-		                ifNone: [
-		                self fail:
-			                'should have a BlFontSizeDefaultAttribute' ].
+	self deny: prevAttributes identicalTo: attributes.
+	fontSizeAttr :=
+		label text iterator
+			detectAttribute: [ :a | a isKindOf: BlFontSizeDefaultAttribute ]
+			ifFound: [ :a | a ]
+			ifNone: [ self fail: 'should have a BlFontSizeDefaultAttribute' ].
 	self
 		assert: fontSizeAttr size
 		equals: (label valueOfTokenNamed: #'font-size')
@@ -158,12 +140,12 @@ ToLabelTest >> testTextChangePreserveAttributes2 [
 { #category : #tests }
 ToLabelTest >> testTextSharedWithInnerElement [
 
-	| lab inner |
-	lab := ToLabel new.
-	lab text: 'A'.
-	self assert: lab text identicalTo: lab innerElement text.
-	inner := lab innerElement.
-	lab beMultiLine.
-	self deny: inner identicalTo: lab innerElement.
-	self assert: lab text identicalTo: lab innerElement text.
+	| label inner |
+	label := ToLabel new.
+	label text: 'A'.
+	self assert: label text identicalTo: label innerElement text.
+	inner := label innerElement.
+	label beMultiLine.
+	self deny: inner identicalTo: label innerElement.
+	self assert: label text identicalTo: label innerElement text
 ]

--- a/src/Toplo-Widget-Button-Tests/ToButtonTest.class.st
+++ b/src/Toplo-Widget-Button-Tests/ToButtonTest.class.st
@@ -14,7 +14,7 @@ ToButtonTest >> testButton [
 	self assert: button isHorizontal.
 
 	self assert: button isStartToEnd.
-	self assert: button isEndToStart equals: false.
+	self deny: button isEndToStart.
 
 	self assert: button icon isNil.
 	self assert: button label isNil
@@ -43,53 +43,52 @@ ToButtonTest >> testCheckable [
 { #category : #'click handler' }
 ToButtonTest >> testClickAborted [
 
-	| but count |
+	| button count |
 	count := 0.
-	but := ToButton new.
-	but labelText: 'XXXXX'.
-	but icon: (ToImage inner: (BlElement new
+	button := ToButton new.
+	button labelText: 'XXXXX'.
+	button icon: (ToImage inner: (BlElement new
 				  extent: 30 @ 30;
 				  background: Color blue;
 				  yourself)).
-	but matchParent.
-	but clickAction: [ count := count + 1 ].
-	space root addChild: but.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but icon.
-	self waitTestingSpaces.
+	button matchParent.
+	button clickAction: [ count := count + 1 ].
+	space deferAndSettle: [ space root addChild: button ].
+
+	button eventSimulator mouseDown.
+	button icon eventSimulator mouseUp.
 	self assert: count equals: 1.
-	BlSpace simulateMouseDownOn: but icon.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+
+	button icon eventSimulator mouseDown.
+	button eventSimulator mouseUp.
 	self assert: count equals: 2.
-	BlSpace simulateMouseDownOn: but label.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+
+	button label eventSimulator mouseDown.
+	button eventSimulator mouseUp.
 	self assert: count equals: 3.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but label.
-	self waitTestingSpaces.
+
+	button eventSimulator mouseDown.
+	button label eventSimulator mouseUp.
 	self assert: count equals: 4
 ]
 
 { #category : #'click handler' }
 ToButtonTest >> testClickAborted2 [
 
-	| but count |
+	| button count |
 	count := 0.
-	but := ToButton new.
-	but labelText: 'XXXXX'.
-	but icon: (ToImage inner: (BlElement new
+	button := ToButton new.
+	button labelText: 'XXXXX'.
+	button icon: (ToImage inner: (BlElement new
 				  extent: 30 @ 30;
 				  background: Color blue;
 				  yourself)).
-	but matchParent.
-	but clickAction: [ count := count + 1 ].
-	space root addChild: but.
-	self waitTestingSpaces.
-	BlSpace simulateMouseDownOn: but label.
-	BlSpace simulateMouseUpOn: but icon.
-	self waitTestingSpaces.
+	button matchParent.
+	button clickAction: [ count := count + 1 ].
+	space deferAndSettle: [ space root addChild: button ].
+
+	button label eventSimulator mouseDown.
+	button icon eventSimulator mouseUp.
 	self assert: count equals: 1
 ]
 
@@ -98,11 +97,10 @@ ToButtonTest >> testClickWhenDisabled [
 
 	| but done |
 	but := ToButton new.
-	but disable.
+	space deferAndSettle: [ but disable ].
 	done := 0.
 	but clickAction: [ done := done +1 ].
-	self assert: done equals: 0.
-	
+	self assert: done equals: 0
 ]
 
 { #category : #'click handler' }
@@ -110,13 +108,11 @@ ToButtonTest >> testClickWith1Action [
 
 	| but done |
 	but := ToButton new.
-	space root addChild: but.
+	space deferAndSettle: [ space root addChild: but ].
 	done := 0.
-	but clickAction: [ done := done +1 ].
+	but clickAction: [ done := done + 1 ].
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 1
-	
 ]
 
 { #category : #'click handler' }
@@ -124,33 +120,23 @@ ToButtonTest >> testClickWith2Actions [
 
 	| but done link1 link2 |
 	but := ToButton new.
-	space root addChild: but.
+	space deferAndSettle: [ space root addChild: but ].
 	done := 0.
 	link1 := but newClickAction: [ done := done + 1 ].
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 1.
+
 	link2 := but newClickAction: [ done := done + 10 ].
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 12.
+
 	link2 unlink.
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 13.
+
 	link1 unlink.
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 13
-
-
-	
-
-
-
-
-	
-	
 ]
 
 { #category : #'click handler' }
@@ -158,8 +144,7 @@ ToButtonTest >> testClickWithoutAction [
 
 	| but |
 	but := ToButton new.
-	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	
+	but dispatchEvent: BlMouseUpEvent primary asClickEvent
 ]
 
 { #category : #'click handler' }
@@ -170,10 +155,9 @@ ToButtonTest >> testLinkClickAction [
 	but := ToButton new.
 	but matchParent.
 	but clickAction: [ count := count + 1 ].
-	space root addChild: but.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: but ].
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: count equals: 1
 ]
 
@@ -182,14 +166,13 @@ ToButtonTest >> testRemoveClickAction [
 
 	| but done link |
 	but := ToButton new.
-	space root addChild: but.
+	space deferAndSettle: [ space root addChild: but ].
 	done := 0.
 	link := but newClickAction: [ done := done + 1 ].
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 1.
+
 	link unlink.
 	but dispatchEvent: BlMouseUpEvent primary asClickEvent.
-	self waitTestingSpaces.
 	self assert: done equals: 1
 ]

--- a/src/Toplo-Widget-Button-Tests/ToCheckboxTest.class.st
+++ b/src/Toplo-Widget-Button-Tests/ToCheckboxTest.class.st
@@ -9,65 +9,37 @@ ToCheckboxTest >> testCheckUncheckStates [
 
 	| cb |
 	cb := ToCheckbox new.
-	self assert: cb checked not.
-	cb checked: true.
+	space deferAndSettle: [ space root addChild: cb ].
+	self deny: cb checked.
+
+	space deferAndSettle: [ cb checked: true ].
 	self assert: cb checked
-]
-
-{ #category : #tests }
-ToCheckboxTest >> testChecked [
-
-	| cb  |
-	cb := ToCheckbox new.
-	cb checked: true.
-	self assert: cb checked.
-	cb disable.
-	self assert: cb checked.
-	
-
-]
-
-{ #category : #tests }
-ToCheckboxTest >> testCheckedDisabledInSpace [
-
-	| chb |
-	chb := ToCheckbox new label: (ToLabel text: 'Checkbox').
-	chb checked: true.
-	self assert: chb icon isNil.
-	space root addChild: chb.
-	self assert: chb icon notNil.
-	space applyAllSkinPhases.
-	self assert: chb icon notNil.
-	chb disabled: true.
-
-]
-
-{ #category : #tests }
-ToCheckboxTest >> testCheckedDisabledInSpace2 [
-
-	| chb |
-	chb := ToCheckbox new label: (ToLabel text: 'Checkbox').
-	chb checked: true.
-	chb disabled: true.
-	space root addChild: chb.
-	space applyAllSkinPhases.
-	self assert: chb icon notNil
 ]
 
 { #category : #tests }
 ToCheckboxTest >> testCheckedWhenDisabled [
 
-	| cb  checked |
+	| checked cb |
 	cb := ToCheckbox new.
 	checked := cb isChecked.
 	cb checked: checked not.
 	self deny: cb isChecked equals: checked.
+
 	cb disable.
 	checked := cb isChecked.
 	cb checked: checked not.
-	self assert: cb isChecked equals: checked.
-	
+	self assert: cb isChecked equals: checked
+]
 
+{ #category : #tests }
+ToCheckboxTest >> testIcon [
+
+	| cb |
+	cb := ToCheckbox new.
+	self assert: cb icon isNil.
+
+	space deferAndSettle: [ space root addChild: cb ].
+	self assert: cb icon notNil "Skin sets the icon"
 ]
 
 { #category : #tests }
@@ -75,9 +47,24 @@ ToCheckboxTest >> testIndeterminateState [
 
 	| cb |
 	cb := ToCheckbox new.
-	self should: [ cb checked: nil] raise: Error.
+	space deferAndSettle: [ space root addChild: cb ].
+	self should: [ cb checked: nil ] raise: Error.
 	self assert: cb isIndeterminate not.
 	self assert: cb isUnchecked 
+]
+
+{ #category : #tests }
+ToCheckboxTest >> testLabel [
+
+	| cb |
+	cb := ToCheckbox new.
+	self assert: cb label isNil.
+
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb label: (ToLabel text: 'Checkbox') ].
+
+	self assert: cb label text asString equals: 'Checkbox'
 ]
 
 { #category : #tests }
@@ -85,40 +72,15 @@ ToCheckboxTest >> testStartChecked [
 
 	| cb |
 	cb := ToCheckbox new.
-	cb checked: true.
-	space root addChild: cb.
+	self deny: cb checked.
+
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb checked: true ].
 	self assert: cb checked.
-	cb addEventHandler: (BlEventHandler
-			 on: ToAddedToSpaceEvent 
-			 do: [ space close ])
-]
 
-{ #category : #tests }
-ToCheckboxTest >> testStartCheckedThenDisabled [
-
-	| cb |
-	cb := ToCheckbox new.
-	cb checked: true.
-	space root addChild: cb.
-	self assert: cb checked.
-	cb disable.
-	self assert: cb checked.
-	cb addEventHandler: (BlEventHandler
-			 on: ToAddedToSpaceEvent 
-			 do: [ space close ])
-]
-
-{ #category : #tests }
-ToCheckboxTest >> testStartUnchecked [
-
-	| cb |
-	cb := ToCheckbox new.
-	cb checked: false.
-	space root addChild: cb.
-	self assert: cb checked not.
-	cb addEventHandler: (BlEventHandler
-			 on: ToAddedToSpaceEvent 
-			 do: [ space close ])
+	space deferAndSettle: [ cb disable ].
+	self assert: cb checked
 ]
 
 { #category : #tests }
@@ -126,12 +88,15 @@ ToCheckboxTest >> testSwitchToNextCheckStateOnClick [
 
 	| cb |
 	cb := ToCheckbox new.
-	space root addChild: cb.
+	space deferAndSettle: [ space root addChild: cb ].
 	self deny: cb checked.
-	BlSpace simulateClickOn: cb.
+
+	cb eventSimulator click.
 	self assert: cb checked.
-	cb switchToNextCheckStateOnClick: false.
-	BlSpace simulateClickOn: cb.
+
+	space deferAndSettle: [
+		cb switchToNextCheckStateOnClick: false ].
+	cb eventSimulator click.
 	self assert: cb checked
 ]
 
@@ -140,10 +105,12 @@ ToCheckboxTest >> testSwitchToNextCheckStateOnDoubleClick [
 
 	| cb |
 	cb := ToCheckbox new.
-	space root addChild: cb.
+	space deferAndSettle: [ space root addChild: cb ].
 	self deny: cb checked.
-	BlSpace simulateClickOn: cb.
+
+	cb eventSimulator click.
 	self assert: cb checked.
-	BlSpace simulateClickOn: cb.
+
+	cb eventSimulator click.
 	self deny: cb checked
 ]

--- a/src/Toplo-Widget-Image-Tests/ToImageTest.class.st
+++ b/src/Toplo-Widget-Image-Tests/ToImageTest.class.st
@@ -3,7 +3,7 @@ A ToImageTest is a test class for testing the behavior of ToImage
 "
 Class {
 	#name : #ToImageTest,
-	#superclass : #TestCase,
+	#superclass : #ToParameterizedHostTest,
 	#category : #'Toplo-Widget-Image-Tests'
 }
 
@@ -14,7 +14,8 @@ ToImageTest >> testEmptyImage [
 	im := ToImage new.
 	self assert: (im innerImage isKindOf: BlElement).
 	self assert: im innerFormImage isNil.
-	im forceLayout.
+
+	space deferAndSettle: [ space root addChild: im ].
 	self assert: im extent equals: im defaultInnerImage extent.
 	passedHere := false.
 	self
@@ -34,13 +35,14 @@ ToImageTest >> testEmptyImage [
 ToImageTest >> testImageWithForm [
 
 	| im form passedHere found |
-	form := Smalltalk ui icons iconNamed: #delete.
+	form := self iconNamed: #delete.
 	im := ToImage new innerImage: form.
 	self assert: (im innerImage isKindOf: BlElement).
 	self assert: (im innerImage background isKindOf: BlImageBackground).
 	self assert: im innerImage background image equals: form.
 	self assert: im innerFormImage equals: form.
-	im forceLayout.
+
+	space deferAndSettle: [ space root addChild: im ].
 	self assert: im extent equals: form extent.
 	passedHere := false.
 	im withInnerFormDo: [ :f | passedHere := true ].

--- a/src/Toplo-Widget-List-Tests/ToBasicFiniteListElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToBasicFiniteListElementTest.class.st
@@ -7,13 +7,6 @@ Class {
 	#category : #'Toplo-Widget-List-Tests-Core-FiniteListElement'
 }
 
-{ #category : #running }
-ToBasicFiniteListElementTest >> setUp [ 
-
-	super setUp.
-	l := ToBasicListElement finite.
-]
-
 { #category : #accessing }
 ToBasicFiniteListElementTest >> statesOfAmerica [
 
@@ -31,8 +24,20 @@ ToBasicFiniteListElementTest >> statesOfAmerica [
 { #category : #tests }
 ToBasicFiniteListElementTest >> testDataAccessorAddAll [
 
+	l := ToBasicListElement finite.
 	l dataAccessor addAll: self statesOfAmerica.
-	self waitTestingSpaces.
-	self assert: l dataSource size equals: self statesOfAmerica size.
-	space root addChild: l
+	space deferAndSettle: [ space root addChild: l ].
+
+	self assert: l dataSource size equals: self statesOfAmerica size
+]
+
+{ #category : #tests }
+ToBasicFiniteListElementTest >> testDataAccessorAddAllAfterAttach [
+
+	l := ToBasicListElement finite.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: self statesOfAmerica ].
+
+	self assert: l dataSource size equals: self statesOfAmerica size
 ]

--- a/src/Toplo-Widget-List-Tests/ToBasicInfiniteListElementStressTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToBasicInfiniteListElementStressTest.class.st
@@ -163,26 +163,27 @@ ToBasicInfiniteListElementStressTest >> randIndex [
 { #category : #tests }
 ToBasicInfiniteListElementStressTest >> runStress [
 
-	| sem |
-	list dataAccessor addAll:
-		((1 to: size) collect: [ :i | 'Hello ' , i asString ]).
-	list matchParent.
+	| isFinished |
+	space deferAndSettle: [ 
+		list dataAccessor addAll:
+			((1 to: size) collect: [ :i | 'Hello ' , i asString ]).
+		list matchParent.
+		space root addChild: list ].
 
-	sem := Semaphore new.
+	isFinished := false.
 	process := [
-		           round := 0.
-		           maxRound timesRepeat: [
-				           round := round + 1.
-				           self selectActionsToRun shuffled do: [ :act |
-					           self perform: act with: list ] ].
-		           sem signal ] newProcess.
+		round := 0.
+		maxRound timesRepeat: [
+			round := round + 1.
+			self selectActionsToRun shuffled do: [ :act |
+				space deferAndSettle: [ self perform: act with: list ] ] ].
+		isFinished := true ] newProcess.
 	process name: self class name.
 
-	space root addChild: list.
-	self waitTestingSpaces.
-
 	process resume.
-	sem wait.
+	
+	space waitUntilTrue: [ isFinished ].
+
 	self assert: round equals: maxRound
 ]
 
@@ -205,9 +206,8 @@ ToBasicInfiniteListElementStressTest >> setUp [
 { #category : #running }
 ToBasicInfiniteListElementStressTest >> tearDown [
 
-	process terminate.
-	super tearDown.
-
+	process ifNotNil: [ process terminate ].
+	super tearDown
 ]
 
 { #category : #tests }

--- a/src/Toplo-Widget-List-Tests/ToCheckableListElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToCheckableListElementTest.class.st
@@ -13,10 +13,11 @@ Class {
 { #category : #tests }
 ToCheckableListElementTest >> add2Items [
 
-	bar addItem: (ToToggleButton new labelText: 'First').
-	bar addItem: (ToToggleButton new labelText: 'Second').
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		bar addItem: (ToToggleButton labelText: 'First').
+		bar addItem: (ToToggleButton labelText: 'Second') ].
 	self assert: bar items size equals: 2.
+
 	bar items withIndexDo: [ :it :idx |
 		self assert: it holder position equals: idx ]
 ]
@@ -24,11 +25,10 @@ ToCheckableListElementTest >> add2Items [
 { #category : #tests }
 ToCheckableListElementTest >> addAllItems [
 
-	bar addAllItems:
-		((self statesOfAmerica "copyFrom: 1 to: 2") collect: [ :l |
-			 ToToggleButton new labelText: l ]).
-	bar forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		bar addAllItems:
+			((self statesOfAmerica) collect: [ :l |
+				 ToToggleButton labelText: l ]) ].
 	self assert: bar items size equals: self statesOfAmerica size.
 	bar nodeContainers withIndexDo: [ :it :idx |
 		self assert: it holder position equals: idx ].
@@ -55,10 +55,11 @@ ToCheckableListElementTest >> addAllItems [
 { #category : #tests }
 ToCheckableListElementTest >> addItem [
 
-	bar addItem: (ToToggleButton new labelText: 'First').
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		bar addItem: (ToToggleButton labelText: 'First') ].
 	self assert: bar isVertical.
 	self assert: bar items size equals: 1.
+
 	bar items withIndexDo: [ :it :idx |
 		self assert: it holder position equals: idx ]
 ]
@@ -66,10 +67,14 @@ ToCheckableListElementTest >> addItem [
 { #category : #tests }
 ToCheckableListElementTest >> bar2 [
 
-	self statesOfAmerica do: [ :l |
-		bar addItem: (ToToggleButton new labelText: l) ].
-	self waitTestingSpaces.
-	self assert: bar items size equals: self statesOfAmerica size.
+	space deferAndSettle: [ 
+		self statesOfAmerica do: [ :l |
+			bar addItem: (ToToggleButton labelText: l) ] ].
+
+	self
+		assert: bar items size
+		equals: self statesOfAmerica size.
+
 	bar items withIndexDo: [ :it :idx |
 		self assert: it holder position equals: idx ]
 ]
@@ -77,73 +82,91 @@ ToCheckableListElementTest >> bar2 [
 { #category : #tests }
 ToCheckableListElementTest >> itemChecked [
 
-	self statesOfAmerica do: [ :l |
-		bar addItem: (ToToggleButton new labelText: l) ].
-	self waitTestingSpaces.
-	bar items first checked: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		self statesOfAmerica do: [ :l |
+			bar addItem: (ToToggleButton labelText: l) ] ].
+	"Must be in a separate block to let the layout loop add children before setting checking state"
+	space deferAndSettle: [ bar items first checked: true ].
 	self assert: bar items first isChecked.
-	self waitTestingSpaces.
 	self assert: bar selectionModel selectedIndexes equals: #( 1 )
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> itemHResizer [
 
-	self statesOfAmerica do: [ :l |
-		bar addItem: (ToToggleButton new labelText: l) ].
-	self waitTestingSpaces.
-	bar items do: [ :item | self assert: item isHMatchParent ]
+	space deferAndSettle: [ 
+		self statesOfAmerica do: [ :l |
+			bar addItem: (ToToggleButton labelText: l) ] ].
+	bar items do: [ :item |
+		| isMatchParent |
+		isMatchParent := item isHMatchParent.
+		self assert: isMatchParent ]
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> itemHeight [
 
-	bar removeAllItems.
-	self assert: bar items size equals: 0.
-	self statesOfAmerica do: [ :l |
-			bar addItem: (ToToggleButton new
+	| sizeBefore |
+	space deferAndSettle: [ 
+		bar removeAllItems.
+		sizeBefore := bar items size.
+		self statesOfAmerica do: [ :l |
+			bar addItem:
+				(ToToggleButton new
 					 labelText: l;
 					 height: 100;
-					 yourself) ].
-	self waitTestingSpaces.
-	bar items do: [ :item | self assert: item height equals: 100 ]
+					 yourself) ] ].
+	self assert: sizeBefore equals: 0.
+
+	bar items do: [ :item |
+		| h |
+		h := item constraints vertical resizer size.
+		self assert: h equals: 100 ]
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> itemSelected [
 
-	self statesOfAmerica do: [ :l |
-		bar addItem: (ToToggleButton new labelText: l) ].
-	bar selecter selectIndex: 1.
-	bar forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		self statesOfAmerica do: [ :l |
+			bar addItem: (ToToggleButton labelText: l) ] ].
+	"Must be in a separate block to let the layout loop add children before setting selection state"
+	space deferAndSettle: [ bar selecter selectIndex: 1 ].
 	self assert: bar items first isChecked.
-	self waitTestingSpaces.
 	self assert: bar selectionModel selectedIndexes equals: #( 1 )
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> itemVResizer [
 
-	self statesOfAmerica do: [ :l |
-		bar addItem: (ToToggleButton new labelText: l) ].
-	self waitTestingSpaces.
-	bar items do: [ :item | self assert: item isVFitContent ]
+	space deferAndSettle: [ 
+		self statesOfAmerica do: [ :l |
+			bar addItem: (ToToggleButton labelText: l) ] ].
+	bar items do: [ :item |
+		| isFitContent |
+		isFitContent := item isVFitContent.
+		self assert: isFitContent ]
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> itemWidth [
 
-	bar removeAllItems.
-	self assert: bar items size equals: 0.
-	self statesOfAmerica do: [ :l |
-			bar addItem: (ToToggleButton new
+	| sizeBefore |
+	space deferAndSettle: [ 
+		bar removeAllItems.
+		sizeBefore := bar items size.
+		self statesOfAmerica do: [ :l |
+			bar addItem:
+				(ToToggleButton new
 					 labelText: l;
 					 width: 1000;
-					 yourself) ].
-	self waitTestingSpaces.
-	bar items do: [ :item | self assert: item width equals: 1000 ]
+					 yourself) ] ].
+
+	self assert: sizeBefore equals: 0.
+	bar items do: [ :item |
+		| w |
+		w := item constraints horizontal resizer size.
+		self assert: w equals: 1000 ]
 ]
 
 { #category : #running }
@@ -151,10 +174,10 @@ ToCheckableListElementTest >> setUp [
 
 	super setUp.
 	bar := ToCheckableListElement new.
-	space root addChild: bar.
-	bar matchParent.
-	bar height: 30000.
-
+	space deferAndSettle: [ 
+		space root addChild: bar.
+		bar matchParent.
+		bar height: 30000 ].
 ]
 
 { #category : #accessing }
@@ -168,145 +191,145 @@ ToCheckableListElementTest >> statesOfAmerica [
 		#'New York'. #'North Carolina'. #'North Dakota'. #Ohio. #Oklahoma.
 		#Oregon. #'Pennsylvania Rhode Island'. #'South Carolina'.
 		#'South Dakota'. #Tennessee. #Texas. #Utah. #Vermont. #Virginia.
-		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }.
+		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteAdd2Items [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self add2Items 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteAddAllItems [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self addAllItems 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteAddItem [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self addItem
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteBar2 [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self bar2
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemChecked [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemChecked 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemHResizer [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemHResizer 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemHeight [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemHeight 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemSelected [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemSelected
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemVResizer [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemVResizer 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testFiniteItemWidth [
 
-	bar useInfiniteLayout: false.
+	space deferAndSettle: [ bar useInfiniteLayout: false ].
 	self itemWidth
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteAdd2Items [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self add2Items 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteAddAllItems [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self addAllItems 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteAddItem [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self addItem
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteBar2 [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self bar2
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemChecked [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemChecked 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemHResizer [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemHResizer 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemHeight [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemHeight 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemSelected [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemSelected
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemVResizer [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemVResizer 
 ]
 
 { #category : #tests }
 ToCheckableListElementTest >> testInfiniteItemWidth [
 
-	bar useInfiniteLayout: true.
+	space deferAndSettle: [ bar useInfiniteLayout: true ].
 	self itemWidth
 ]

--- a/src/Toplo-Widget-List-Tests/ToFiniteListElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToFiniteListElementTest.class.st
@@ -23,17 +23,13 @@ ToFiniteListElementTest >> testDisabledWithFiveNodes [
 	l dataAccessor removeAll.
 	l removeFromParent.
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
-	l dataAccessor add: 'third'.
-	self waitTestingSpaces.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: 'fifth'.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l disabledSelecter selectOneMoreIndex: 1.
+		l dataAccessor addFirst: 'second'.
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' afterIndex: 2.
+		l dataAccessor addFirst: 'fifth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -51,9 +47,7 @@ ToFiniteListElementTest >> testDisabledWithFiveNodesLateAddToSpace [
 	l dataAccessor add: 'third'.
 	l dataAccessor add: 'fourth' afterIndex: 2.
 	l dataAccessor addFirst: 'fifth'.
-	space root addChild: l.
-	l forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -66,19 +60,16 @@ ToFiniteListElementTest >> testDisabledWithFiveNodesLateAddToSpace [
 ToFiniteListElementTest >> testDisabledWithFourNodes [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 1 }.
-	self waitTestingSpaces.
 	self assert: l nodes first isDisabled.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
-	l dataAccessor add: 'third'.
-	self waitTestingSpaces.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l dataAccessor addFirst: 'second'.
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' afterIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first  isEnabled.
 	self assert: l nodes second  isDisabled.
@@ -89,14 +80,13 @@ ToFiniteListElementTest >> testDisabledWithFourNodes [
 { #category : #tests }
 ToFiniteListElementTest >> testDisabledWithFourNodes2 [
 
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	l dataAccessor add: 'second'.
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 2.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth'.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l dataAccessor add: 'first'.
+		l dataAccessor add: 'second'.
+		l disabledSelecter selectOneMoreIndex: 2.
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -112,8 +102,7 @@ ToFiniteListElementTest >> testDisabledWithFourNodesLateAddToSpace [
 	l dataAccessor addFirst: 'second'.
 	l dataAccessor add: 'third'.
 	l dataAccessor add: 'fourth' afterIndex: 2.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -129,8 +118,7 @@ ToFiniteListElementTest >> testDisabledWithFourNodesLateAddToSpace2 [
 	l disabledSelecter selectOneMoreIndex: 2.
 	l dataAccessor add: 'third'.
 	l dataAccessor add: 'fourth'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -142,14 +130,12 @@ ToFiniteListElementTest >> testDisabledWithFourNodesLateAddToSpace2 [
 ToFiniteListElementTest >> testDisabledWithOneNode [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	self waitTestingSpaces.
 	self assert: l nodes first isDisabled
 ]
 
@@ -157,19 +143,18 @@ ToFiniteListElementTest >> testDisabledWithOneNode [
 ToFiniteListElementTest >> testDisabledWithThreeNodes [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: 'third'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: 'third' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -183,8 +168,7 @@ ToFiniteListElementTest >> testDisabledWithThreeNodesLateAddToSpace [
 	l disabledSelecter selectOneMoreIndex: 1.
 	l dataAccessor addFirst: 'second'.
 	l dataAccessor add: 'third'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -195,18 +179,14 @@ ToFiniteListElementTest >> testDisabledWithThreeNodesLateAddToSpace [
 ToFiniteListElementTest >> testDisabledWithTwoNodes [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
@@ -217,18 +197,16 @@ ToFiniteListElementTest >> testDisabledWithTwoNodes [
 ToFiniteListElementTest >> testDisabledWithTwoNodes2 [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	self waitTestingSpaces.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled
 ]
@@ -239,22 +217,7 @@ ToFiniteListElementTest >> testDisabledWithTwoNodesLateAddToSpace [
 	l dataAccessor add: 'first'.
 	l disabledSelecter selectOneMoreIndex: 1.
 	l dataAccessor addFirst: 'second'.
-	space root addChild: l.
-	self waitTestingSpaces.
-	self assert: l disabledSelecter selectedIndex equals: 2.
-	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	self assert: l nodes first isEnabled.
-	self assert: l nodes second isDisabled
-]
-
-{ #category : #tests }
-ToFiniteListElementTest >> testDisabledWithTwoNodesLateAddToSpace2 [
-
-	l dataAccessor add: 'first'.
-	l disabledSelecter selectOneMoreIndex: 1.
-	l dataAccessor addFirst: 'second'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
@@ -277,9 +240,9 @@ ToFiniteListElementTest >> testEmptyList [
 { #category : #tests }
 ToFiniteListElementTest >> testOneNode [
 
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l dataAccessor add: 'first' ].
 	self assert: l dataSource first equals: 'first'.
 	self assert: l nodes  size equals: 1.
 	self assert: l nodes first class identicalTo: ToListNodeForTest.	
@@ -296,12 +259,11 @@ ToFiniteListElementTest >> testOneNode [
 ToFiniteListElementTest >> testSelectionWithOneNode [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
 	self assert: l selectionModel selectedIndexes equals: { 1 }
 ]
@@ -310,15 +272,14 @@ ToFiniteListElementTest >> testSelectionWithOneNode [
 ToFiniteListElementTest >> testSelectionWithTwoNodes [
 
 	l dataAccessor add: 'first'.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l selecter selectedIndex equals: 2.
 	self assert: l selecter selectedIndexes equals: { 2 }
 ]

--- a/src/Toplo-Widget-List-Tests/ToFiniteListElementTest2.class.st
+++ b/src/Toplo-Widget-List-Tests/ToFiniteListElementTest2.class.st
@@ -22,16 +22,12 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodes [
 
 	l dataAccessor add: (ToLabel text: 'first').
 	l disabledSelecter selectOneMoreIndex: 1.
-	space root addChild: l.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	self waitTestingSpaces.
-	l dataAccessor add: (ToLabel text: 'third').
-	self waitTestingSpaces.
-	l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: (ToLabel text: 'fifth').
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addFirst: (ToLabel text: 'second').
+		l dataAccessor add: (ToLabel text: 'third').
+		l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2.
+		l dataAccessor addFirst: (ToLabel text: 'fifth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -43,22 +39,20 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodes [
 { #category : #tests }
 ToFiniteListElementTest2 >> testDisabledWithFiveNodes2 [
 
-	space root addChild: l.
-	l dataAccessor add: (ToLabel text: 'first').
-	l dataAccessor add: (ToLabel text: 'second').
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
-	l forceLayout.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l dataAccessor add: (ToLabel text: 'first').
+		l dataAccessor add: (ToLabel text: 'second').
+		l disabledSelecter selectOneMoreIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: (ToLabel text: 'third').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'third') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: (ToLabel text: 'fourth').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'fourth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: (ToLabel text: 'fifth').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'fifth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -70,21 +64,22 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodes2 [
 { #category : #tests }
 ToFiniteListElementTest2 >> testDisabledWithFiveNodes4 [
 
-	space root addChild: l.
-	l dataAccessor add: (ToLabel text: 'first').
-	l dataAccessor add: (ToLabel text: 'second').
-	self waitTestingSpaces.
-	l disabledSelecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor add: (ToLabel text: 'first').
+		l dataAccessor add: (ToLabel text: 'second') ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l disabledSelecter selectIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: (ToLabel text: 'third').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'third') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor addFirst: (ToLabel text: 'fourth').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: (ToLabel text: 'fourth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
-	l dataAccessor add: (ToLabel text: 'fifth').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'fifth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -102,8 +97,7 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodesLateAddToSpace [
 	l dataAccessor add: (ToLabel text: 'third').
 	l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2.
 	l dataAccessor addFirst: (ToLabel text: 'fifth').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -121,8 +115,7 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodesLateAddToSpace2 [
 	l dataAccessor add: (ToLabel text: 'third').
 	l dataAccessor add: (ToLabel text: 'fourth').
 	l dataAccessor add: (ToLabel text: 'fifth').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -140,8 +133,7 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodesLateAddToSpace4 [
 	l dataAccessor add: (ToLabel text: 'third').
 	l dataAccessor addFirst: (ToLabel text: 'fourth').
 	l dataAccessor add: (ToLabel text: 'fifth').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -154,16 +146,12 @@ ToFiniteListElementTest2 >> testDisabledWithFiveNodesLateAddToSpace4 [
 ToFiniteListElementTest2 >> testDisabledWithFourNodes [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	self waitTestingSpaces.
-	l dataAccessor add: (ToLabel text: 'third').
-	self waitTestingSpaces.
-	l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l disabledSelecter selectOneMoreIndex: 1.
+		l dataAccessor addFirst: (ToLabel text: 'second').
+		l dataAccessor add: (ToLabel text: 'third').
+		l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -174,15 +162,13 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodes [
 { #category : #tests }
 ToFiniteListElementTest2 >> testDisabledWithFourNodes2 [
 
-	space root addChild: l.
-	l dataAccessor add: (ToLabel text: 'first').
-	l dataAccessor add: (ToLabel text: 'second').
-	l innerElement forceLayout.
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 2.
-	l dataAccessor add: (ToLabel text: 'third').
-	l dataAccessor add: (ToLabel text: 'fourth').
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l dataAccessor add: (ToLabel text: 'first').
+		l dataAccessor add: (ToLabel text: 'second').
+		l disabledSelecter selectOneMoreIndex: 2.
+		l dataAccessor add: (ToLabel text: 'third').
+		l dataAccessor add: (ToLabel text: 'fourth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -193,17 +179,13 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodes2 [
 { #category : #tests }
 ToFiniteListElementTest2 >> testDisabledWithFourNodes3 [
 
-	space root addChild: l.
-	l forceLayout.
-	l dataAccessor add: (ToLabel text: 'first').
-	l dataAccessor add: (ToLabel text: 'second').
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
-	l dataAccessor addFirst: (ToLabel text: 'third').
-	self waitTestingSpaces.
-	l dataAccessor add: (ToLabel text: 'fourth').
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor add: (ToLabel text: 'first').
+		l dataAccessor add: (ToLabel text: 'second').
+		l disabledSelecter selectOneMoreIndex: 2.
+		l dataAccessor addFirst: (ToLabel text: 'third').
+		l dataAccessor add: (ToLabel text: 'fourth') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -219,8 +201,7 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodesLateAddToSpace [
 	l dataAccessor addFirst: (ToLabel text: 'second').
 	l dataAccessor add: (ToLabel text: 'third').
 	l dataAccessor add: (ToLabel text: 'fourth') afterIndex: 2.
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -236,8 +217,7 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodesLateAddToSpace2 [
 	l disabledSelecter selectOneMoreIndex: 2.
 	l dataAccessor add: (ToLabel text: 'third').
 	l dataAccessor add: (ToLabel text: 'fourth').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -253,8 +233,7 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodesLateAddToSpace3 [
 	l disabledSelecter selectOneMoreIndex: 2.
 	l dataAccessor addFirst: (ToLabel text: 'third').
 	l dataAccessor add: (ToLabel text: 'fourth').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isEnabled.
@@ -266,12 +245,11 @@ ToFiniteListElementTest2 >> testDisabledWithFourNodesLateAddToSpace3 [
 ToFiniteListElementTest2 >> testDisabledWithOneNode [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1
 ]
 
@@ -279,18 +257,17 @@ ToFiniteListElementTest2 >> testDisabledWithOneNode [
 ToFiniteListElementTest2 >> testDisabledWithThreeNodes [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: (ToLabel text: 'second') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: (ToLabel text: 'third').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (ToLabel text: 'third') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -304,8 +281,7 @@ ToFiniteListElementTest2 >> testDisabledWithThreeNodesLateAddToSpace [
 	l disabledSelecter selectOneMoreIndex: 1.
 	l dataAccessor addFirst: (ToLabel text: 'second').
 	l dataAccessor add: (ToLabel text: 'third').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled.
@@ -316,17 +292,14 @@ ToFiniteListElementTest2 >> testDisabledWithThreeNodesLateAddToSpace [
 ToFiniteListElementTest2 >> testDisabledWithTwoNodes [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	l forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: (ToLabel text: 'second') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled
@@ -336,17 +309,15 @@ ToFiniteListElementTest2 >> testDisabledWithTwoNodes [
 ToFiniteListElementTest2 >> testDisabledWithTwoNodes2 [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: (ToLabel text: 'second') ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	self waitTestingSpaces.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled
 ]
@@ -357,8 +328,7 @@ ToFiniteListElementTest2 >> testDisabledWithTwoNodesLateAddToSpace [
 	l dataAccessor add: (ToLabel text: 'first').
 	l disabledSelecter selectOneMoreIndex: 1.
 	l dataAccessor addFirst: (ToLabel text: 'second').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
 	self assert: l nodes first isEnabled.
 	self assert: l nodes second isDisabled
@@ -380,9 +350,9 @@ ToFiniteListElementTest2 >> testEmptyList [
 { #category : #tests }
 ToFiniteListElementTest2 >> testOneNode [
 
-	space root addChild: l.
-	l dataAccessor add: (ToLabel text: 'first').
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l dataAccessor add: (ToLabel text: 'first') ].
 	self assert: l dataSource first text asString equals: 'first'.
 	self assert: l nodeContainers  size equals: 1.
 	self assert: l nodes first class identicalTo: ToListNodeForTest.	
@@ -399,12 +369,11 @@ ToFiniteListElementTest2 >> testOneNode [
 ToFiniteListElementTest2 >> testSelectionWithOneNode [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
 	self assert: l selectionModel selectedIndexes equals: { 1 }
 ]
@@ -413,15 +382,14 @@ ToFiniteListElementTest2 >> testSelectionWithOneNode [
 ToFiniteListElementTest2 >> testSelectionWithTwoNodes [
 
 	l dataAccessor add: (ToLabel text: 'first').
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
-	l dataAccessor addFirst: (ToLabel text: 'second').
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: (ToLabel text: 'second') ].
 	self assert: l selecter selectedIndex equals: 2.
 	self assert: l selecter selectedIndexes equals: { 2 }
 ]

--- a/src/Toplo-Widget-List-Tests/ToInfiniteCollectionDataSourceTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToInfiniteCollectionDataSourceTest.class.st
@@ -34,11 +34,11 @@ ToInfiniteCollectionDataSourceTest >> statesOfAmerica [
 { #category : #tests }
 ToInfiniteCollectionDataSourceTest >> testEmptyInfinite [
 
-	l constraintsDo: [ :c |
+	space deferAndSettle: [
+		l constraintsDo: [ :c |
 			c vertical fitContent.
-			c horizontal fitContent ].
+			c horizontal fitContent ] ].
 
-	l forceLayout.
 	self assert: l children size equals: 0.
 	self
 		assert: l extent
@@ -50,13 +50,12 @@ ToInfiniteCollectionDataSourceTest >> testEmptyInfinite [
 { #category : #tests }
 ToInfiniteCollectionDataSourceTest >> testInfiniteWithOneElement [
 
-	l dataSource collection add: self statesOfAmerica first.
-	l constraintsDo: [ :c |
-		c vertical matchParent.
-		c horizontal matchParent ].
+	space deferAndSettle: [
+		l dataSource collection add: self statesOfAmerica first.
+		l constraintsDo: [ :c |
+			c vertical matchParent.
+			c horizontal matchParent ] ].
 
-	self assert: l children size equals: 0.
-	self waitTestingSpaces.
 	self assert: l children size equals: 1
 ]
 

--- a/src/Toplo-Widget-List-Tests/ToItemListElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToItemListElementTest.class.st
@@ -16,14 +16,14 @@ ToItemListElementTest >> add1To10 [
 	| n |
 	self assert: l nodeContainers size equals: l dataAccessor size.
 	self assert: (l nodeManager isKindOf: ToItemListNodeManager).
-	l addAllItems:
-		((1 to: 10) collect: [ :i | ToItemElementForTest new text: i asString ]).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ 
+		l addAllItems:
+			((1 to: 10) collect: [ :i | ToItemElementForTest new text: i asString ]) ].
 	n := l nodes first.
 	self assert: (n isKindOf: ToItemNodeForTest).
 	self assert: (n holder isKindOf: ToItemListNodeHolderForTest).
 	self assert: (n holder dataItem isKindOf: ToItemElementForTest)
-	
 ]
 
 { #category : #tests }
@@ -31,11 +31,10 @@ ToItemListElementTest >> addAllItems [
 
 	| bar |
 	bar := l.
-	bar addAllItems:
-		((self statesOfAmerica ) collect: [ :v |
-			 ToToggleButton new labelText: v ]).
-	bar forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		bar addAllItems:
+			((self statesOfAmerica ) collect: [ :v |
+				 ToToggleButton labelText: v ]) ].
 	bar nodeContainers withIndexDo: [ :it :idx |
 		self assert: it holder position equals: idx ].
 	bar nodeContainers withIndexDo: [ :it :idx |
@@ -63,8 +62,7 @@ ToItemListElementTest >> addItem [
 
 	| n item |
 	item := ToItemElementForTest new text: '#1'.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l addItem: item ].
 	self assert: l nodeContainers size equals: 1.
 	n := l nodes first.
 	self assert: (n isKindOf: ToItemNodeForTest).
@@ -80,10 +78,9 @@ ToItemListElementTest >> disableItemAfterAdding [
 	| n item |
 	self assert: l nodeContainers size equals: 0.
 	item := ToItemElementForTest new text: 'A'.
-	l addItem: item.
-	item disable.
-	self waitTestingSpaces.
-	l forceLayout.
+	space deferAndSettle: [ 
+		l addItem: item.
+		item disable ].
 
 	n := l nodes first.
 	self assert: n holder dataItem identicalTo: item.
@@ -99,14 +96,15 @@ ToItemListElementTest >> disableItemAfterAdding2 [
 
 	| n item |
 	self assert: l nodeContainers size equals: 0.
-	item := ToItemElementForTest new text: 'A'.
-	l addItem: item.
-	item := ToItemElementForTest new text: 'B'.
-	l addItem: item.
-	item disable.
-	item := ToItemElementForTest new text: 'C'.
-	l addItem: item.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ 
+		item := ToItemElementForTest new text: 'A'.
+		l addItem: item.
+		item := ToItemElementForTest new text: 'B'.
+		l addItem: item.
+		item disable.
+		item := ToItemElementForTest new text: 'C'.
+		l addItem: item ].
 
 	n := l nodes first.
 	self assert: n item positionInList equals: 1.
@@ -116,7 +114,7 @@ ToItemListElementTest >> disableItemAfterAdding2 [
 	self deny: n isDisabled.
 
 	n := l nodes second.
-	self waitTestingSpaces.
+	space settle.
 	self assert: n item positionInList equals: 2.
 	self assert:
 		(l disabledSelectionModel containsIndex: n item positionInList).
@@ -137,9 +135,9 @@ ToItemListElementTest >> disableItemBeforeAdding [
 	| n item |
 	self assert: l nodeContainers size equals: 0.
 	item := ToItemElementForTest new text: 'A'.
-	item disabled: true.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		item disabled: true.
+		l addItem: item ].
 
 	n := l nodes first.
 	self assert: n holder dataItem identicalTo: item.
@@ -156,14 +154,15 @@ ToItemListElementTest >> disableItemBeforeAdding2 [
 
 	| n item |
 	self assert: l nodeContainers size equals: 0.
-	item := ToItemElementForTest new text: 'A'.
-	l addItem: item.
-	item := ToItemElementForTest new text: 'B'.
-	item disable.
-	l addItem: item.
-	item := ToItemElementForTest new text: 'C'.
-	l addItem: item.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ 
+		item := ToItemElementForTest new text: 'A'.
+		l addItem: item.
+		item := ToItemElementForTest new text: 'B'.
+		item disable.
+		l addItem: item.
+		item := ToItemElementForTest new text: 'C'.
+		l addItem: item ].
 
 	n := l nodes first.
 	self assert: n item positionInList equals: 1.
@@ -172,8 +171,8 @@ ToItemListElementTest >> disableItemBeforeAdding2 [
 	self deny: n item isDisabled.
 	self deny: n isDisabled.
 
+	space settle.
 	n := l nodes second.
-	self waitTestingSpaces.
 	self assert: n item positionInList equals: 2.
 	self assert:
 		(l disabledSelectionModel containsIndex: n item positionInList).
@@ -194,9 +193,9 @@ ToItemListElementTest >> setUp [
 	super setUp.
 	l := ToItemListElementForTest new.
 	l vMatchParent.
-	space root addChild: l.
-	l height: 30000.
-
+	space deferAndSettle: [ 
+		space root addChild: l.
+		l height: 30000 ].
 ]
 
 { #category : #accessing }
@@ -210,103 +209,103 @@ ToItemListElementTest >> statesOfAmerica [
 		#'New York'. #'North Carolina'. #'North Dakota'. #Ohio. #Oklahoma.
 		#Oregon. #'Pennsylvania Rhode Island'. #'South Carolina'.
 		#'South Dakota'. #Tennessee. #Texas. #Utah. #Vermont. #Virginia.
-		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }.
+		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFinite [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self add1To10 
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteAddAllItems [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self addAllItems
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteAddItem [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self addItem
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteDisableItemAfterAdding [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self disableItemAfterAdding
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteDisableItemAfterAdding2 [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self disableItemAfterAdding2
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteDisableItemBeforeAdding [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self disableItemBeforeAdding 
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testFiniteDisableItemBeforeAdding2 [
 
-	l useInfiniteLayout: false.
+	space deferAndSettle: [ l useInfiniteLayout: false ].
 	self disableItemBeforeAdding2
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfinite [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self add1To10
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteAddAllItems [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self addAllItems
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteAddItem [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self addItem
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteDisableItemAfterAdding [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self disableItemAfterAdding
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteDisableItemAfterAdding2 [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self disableItemAfterAdding2
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteDisableItemBeforeAdding [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self disableItemBeforeAdding 
 ]
 
 { #category : #tests }
 ToItemListElementTest >> testInfiniteDisableItemBeforeAdding2 [
 
-	l useInfiniteLayout: true.
+	space deferAndSettle: [ l useInfiniteLayout: true ].
 	self disableItemBeforeAdding2
 ]

--- a/src/Toplo-Widget-List-Tests/ToListElementSelectionSkinEventTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToListElementSelectionSkinEventTest.class.st
@@ -11,23 +11,16 @@ Class {
 ToListElementSelectionSkinEventTest >> selectedSkinEventCountAfterRemove [
 	" check that the skin select event is sent to the right node "
 
-	listElement selecter deselectAll.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	listElement dataAccessor add: self statesOfAmerica first.
-	listElement dataAccessor add: self statesOfAmerica second.
-	self waitTestingSpaces.
-	listElement selecter selectIndex: 2.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	listElement forceLayout.
+	space deferAndSettle: [
+		listElement selecter deselectAll.
+		listElement dataAccessor add: self statesOfAmerica first.
+		listElement dataAccessor add: self statesOfAmerica second ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ listElement selecter selectIndex: 2 ].
 	self assert: listElement nodeContainers size equals: 2.
 	self assert: listElement selectionModel selectedIndexes equals: #( 2 ).
 
-	listElement dataAccessor removeAt: 1.
-	space applyAllSkinPhases.
-	self waitTestingSpaces.
- 	listElement forceLayout.
+	space deferAndSettle: [ listElement dataAccessor removeAt: 1 ].
 	self assert: listElement nodeContainers size equals: 1.
 	self assert: listElement selectionModel selectedIndexes equals: #( 1 ).
 
@@ -43,24 +36,17 @@ ToListElementSelectionSkinEventTest >> selectedSkinEventCountAfterRemove [
 ToListElementSelectionSkinEventTest >> selectedSkinEventCountAfterSelect [
 	" check that the skin select event is sent to the right node "
 
-	listElement dataAccessor add: self statesOfAmerica first.
-	listElement dataAccessor add: self statesOfAmerica second.
-	listElement selecter selectIndex: 2.
-	self waitTestingSpaces.
-	listElement forceLayout.
-	
+	space deferAndSettle: [
+		listElement dataAccessor add: self statesOfAmerica first.
+		listElement dataAccessor add: self statesOfAmerica second ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ listElement selecter selectIndex: 2 ].
 	self assert: listElement nodeContainers size equals: 2.
-	space applyAllSkinPhases.
-	
-	listElement selecter selectOnlyIndex: 1.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
 
-	listElement forceLayout.
+	space deferAndSettle: [ listElement selecter selectOnlyIndex: 1 ].
 	self assert: listElement selectionMode selectionContainer children size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers first holder position equals: 1.
-
 ]
 
 { #category : #'test selection - skin' }
@@ -73,20 +59,12 @@ ToListElementSelectionSkinEventTest >> selectedSkinEventCountAfterSelect2 [
 	self selectedSkinEventCountAfterSelect.
 
 	" here, the selected index is 1 because of #testSelectedSkinEventCountAfterSelect invocation"
-	listElement selecter selectIndex: 2.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	listElement forceLayout.
-	
-	listElement selecter selectOnlyIndex: 1.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	
-	listElement forceLayout.
+	space deferAndSettle: [
+		listElement selecter selectIndex: 2 .
+		listElement selecter selectOnlyIndex: 1 ].
 	self assert: listElement selectionMode selectionContainer children size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers first holder position equals: 1.
-
 ]
 
 { #category : #'test selection - skin' }
@@ -97,20 +75,12 @@ ToListElementSelectionSkinEventTest >> selectedSkinEventCountAfterSelect3 [
 	on the selected node "
 
 	" here, the selected index is 1 because of #testSelectedSkinEventCountAfterSelect invocation"
-	listElement selecter selectOnlyIndex: 2.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	listElement forceLayout.
-	
-	listElement selecter selectOnlyIndex: 1.
-	self waitTestingSpaces.
-	space applyAllSkinPhases.
-	
-	listElement forceLayout.
+	space deferAndSettle: [
+		listElement selecter selectOnlyIndex: 2 .
+		listElement selecter selectOnlyIndex: 1 ].
 	self assert: listElement selectionMode selectionContainer children size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers size equals: 1.
 	self assert: listElement selectionMode selectionContainer children first nodeContainers first holder position equals: 1.
-
 ]
 
 { #category : #running }
@@ -121,11 +91,10 @@ ToListElementSelectionSkinEventTest >> setUp [
 	listElement innerElement.
 	listElement fitContent.
 
-	space root addChild: listElement.
-	listElement nodeBuilder: [ :node :dataItem :holder |
-		node addChild: (ToLabel text: dataItem) ].
-	self waitTestingSpaces.
-	listElement forceLayout
+	space deferAndSettle: [
+		space root addChild: listElement.
+		listElement nodeBuilder: [ :node :dataItem :holder |
+			node addChild: (ToLabel text: dataItem) ] ]
 ]
 
 { #category : #accessing }
@@ -146,8 +115,7 @@ ToListElementSelectionSkinEventTest >> statesOfAmerica [
 ToListElementSelectionSkinEventTest >> testFiniteSelectedSkinEventCountAfterRemove [
 	" check that the skin select event is sent to the right node "
 
-	listElement useInfiniteLayout: false.
-	self waitTestingSpaces.
+	space deferAndSettle: [ listElement useInfiniteLayout: false ].
 	self selectedSkinEventCountAfterRemove
 ]
 
@@ -155,9 +123,7 @@ ToListElementSelectionSkinEventTest >> testFiniteSelectedSkinEventCountAfterRemo
 ToListElementSelectionSkinEventTest >> testFiniteSelectedSkinEventCountAfterSelect [
 	" check that the skin select event is sent to the right node "
 
-	listElement useInfiniteLayout: false.
-	self waitTestingSpaces.
-
+	space deferAndSettle: [ listElement useInfiniteLayout: false ].
 	self selectedSkinEventCountAfterSelect
 ]
 
@@ -168,8 +134,7 @@ ToListElementSelectionSkinEventTest >> testFiniteSelectedSkinEventCountAfterSele
 	(the holder>>selectionNotificationMap map is up to date). So the result is that the deselection is only applied once
 	on the selected node "
 
-	listElement useInfiniteLayout: false.
-	self waitTestingSpaces.
+	space deferAndSettle: [ listElement useInfiniteLayout: false ].
 	self selectedSkinEventCountAfterSelect2
 ]
 
@@ -180,11 +145,10 @@ ToListElementSelectionSkinEventTest >> testFiniteSelectedSkinEventCountAfterSele
 	(the holder>>selectionNotificationMap map is up to date). So the result is that the deselection is only applied once
 	on the selected node "
 
-	listElement useInfiniteLayout: false.
-	self waitTestingSpaces.
+	space deferAndSettle: [ listElement useInfiniteLayout: false ].
 	self selectedSkinEventCountAfterSelect.
-	listElement requestFocus.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ listElement requestFocus ].
 	self selectedSkinEventCountAfterSelect3
 ]
 
@@ -219,10 +183,9 @@ ToListElementSelectionSkinEventTest >> testInfiniteSelectedSkinEventCountAfterSe
 	(the holder>>selectionNotificationMap map is up to date). So the result is that the deselection is only applied once
 	on the selected node "
 
-	listElement useInfiniteLayout: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [ listElement useInfiniteLayout: true ].
 	self selectedSkinEventCountAfterSelect.
-	listElement requestFocus.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ listElement requestFocus ].
 	self selectedSkinEventCountAfterSelect3
 ]

--- a/src/Toplo-Widget-List-Tests/ToListElementSieveTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToListElementSieveTest.class.st
@@ -16,7 +16,7 @@ ToListElementSieveTest >> setUp [
 	super setUp.
 	list := ToListElement new.
 	sieve := list dataAccessor newSieve.
-	space root addChild: list
+	space deferAndSettle: [ space root addChild: list ]
 ]
 
 { #category : #accessing }
@@ -30,7 +30,7 @@ ToListElementSieveTest >> statesOfAmerica [
 		#'New York'. #'North Carolina'. #'North Dakota'. #Ohio. #Oklahoma.
 		#Oregon. #'Pennsylvania Rhode Island'. #'South Carolina'.
 		#'South Dakota'. #Tennessee. #Texas. #Utah. #Vermont. #Virginia.
-		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }.
+		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }
 ]
 
 { #category : #tests }
@@ -40,36 +40,39 @@ ToListElementSieveTest >> testCurrentData [
 	When the sieve  has a pattern, the original data is untouched even the list data source is updated"
 
 	| passedInHandler |
-	sieve filter: [ :anInteger :aPattern |
-		anInteger < aPattern asInteger ].
+	space deferAndSettle: [
+		sieve filter: [ :anInteger :aPattern |
+			anInteger < aPattern asInteger ] ].
 	self assert: sieve currentData isEmpty.
-	list dataAccessor addAll: (1 to: 10).
+
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 10) ].
 	passedInHandler := false.
 	list dataSource addEventHandlerOn: ToCollectionSievedEvent doOnce: [
 			passedInHandler := true.
 			self assert: sieve currentData asArray equals: #( 1 2 3 4 ) ].
-	sieve pattern: '5'.
+
+	space deferAndSettle: [ sieve pattern: '5' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: passedInHandler.
 	
 	passedInHandler := false.
 	list dataSource addEventHandlerOn: ToCollectionSievedEvent doOnce: [
 			passedInHandler := true.
 			self assert: sieve currentData asArray equals: #( 1 2 3 4 5 6 7 8 9 10) ].
-	sieve pattern: ''.
-	500 milliSeconds wait.
-	self waitTestingSpaces.
-	self assert: passedInHandler.
-	
 
+	space deferAndSettle: [ sieve pattern: '' ].
+	500 milliSeconds wait.
+	space settle.
+	self assert: passedInHandler
 ]
 
 { #category : #tests }
 ToListElementSieveTest >> testIsInstalled [
 
 	self assert: sieve isInstalled.
-	sieve onUninstalledIn: list.
+
+	space deferAndSettle: [ sieve onUninstalledIn: list ].
 	self deny: sieve isInstalled
 ]
 
@@ -115,7 +118,7 @@ ToListElementSieveTest >> testOnInstalledInTwiceRaiseError [
 ToListElementSieveTest >> testOnUninstalledIn [
 
 	| handlers |
-	sieve onUninstalledIn: list.
+	space deferAndSettle: [ sieve onUninstalledIn: list ].
 	self assert: sieve originalData isNil.
 	self assert: sieve selecter isNil.
 	self assert: sieve originalIndexMap isNil.
@@ -145,25 +148,29 @@ ToListElementSieveTest >> testOriginalData [
 	When the sieve  has a pattern, the original data is untouched even the list data source is updated"
 
 	| passedInHandler |
-	sieve filter: [ :anInteger :aPattern |
-		anInteger < aPattern asInteger ].
+	space deferAndSettle: [
+		sieve filter: [ :anInteger :aPattern |
+			anInteger < aPattern asInteger ] ].
 	self assert: sieve currentData isEmpty.
-	list dataAccessor addAll: (1 to: 10).
+
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 10) ].
 	self assert: sieve originalData size equals: 10.
 	1 to: 10 do: [ :idx |
 			self
 				assert: (sieve originalData at: idx)
 				equals: (list dataSource at: idx) ].
-	list dataAccessor add: 11.
+
+	space deferAndSettle: [ list dataAccessor add: 11 ].
 	self assert: sieve originalData last equals: 11.
 	passedInHandler := false.
 	list dataSource addEventHandlerOn: ToCollectionSievedEvent do: [
 			passedInHandler := true.
 			self assert: sieve originalData size equals: 11.
 			self assert: sieve currentData asArray equals: #( 1 2 3 4 ) ].
-	sieve pattern: '5'.
+
+	space deferAndSettle: [ sieve pattern: '5' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: passedInHandler
 ]
 
@@ -175,27 +182,21 @@ ToListElementSieveTest >> testOriginalIndexMap [
 
 	self assert: sieve originalIndexMap isEmpty.
 	
-	list dataAccessor addAll: (1 to: 10).
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 10) ].
 	self assert: sieve originalIndexMap size equals: 10.
 	1 to: 10 do: [ :idx |
 			self
 				assert: (sieve originalIndexMap at: idx)
 				equals: (list dataSource at: idx) ].
 			
-	list dataAccessor add: 11.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor add: 11 ].
 	self assert: (sieve originalIndexMap at: 11) equals: 11.
 	
-	list dataAccessor removeFirst.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor removeFirst ].
 	self assert: (sieve originalIndexMap at: 11) equals: 10.
 
-	list dataAccessor at: 1 put: 100.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor at: 1 put: 100 ].
 	self assert: (sieve originalIndexMap at: 100) equals: 1.
-
-
 ]
 
 { #category : #'tests - selection' }
@@ -207,10 +208,10 @@ ToListElementSieveTest >> testOriginalIndexMapWhenDataAreAddedBeforeTheSieve [
 	"
 
 	list := ToListElement new.
-	space root addChild: list.
-	list dataAccessor addAll: (1 to: 10).
-	sieve := list dataAccessor newSieve.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: list.
+		list dataAccessor addAll: (1 to: 10).
+		sieve := list dataAccessor newSieve ].
 	self deny: sieve originalIndexMap isNil.
 	self deny: sieve originalIndexMap isEmpty.
 	
@@ -230,37 +231,36 @@ ToListElementSieveTest >> testOriginalIndexMapWhenDataAreAddedBeforeTheSieve2 [
 	Here te list is added late in the space. The index map update occurs after the list is added in the space   "
 
 	list := ToListElement new.
-	list dataAccessor addAll: (1 to: 10).
-	sieve := list dataAccessor newSieve.
+	space deferAndSettle: [
+		list dataAccessor addAll: (1 to: 10).
+		sieve := list dataAccessor newSieve ].
 	self deny: sieve originalIndexMap isNil.
-	
-	self waitTestingSpaces.
 	self deny: sieve originalIndexMap isEmpty.
 	self assert: sieve originalIndexMap size equals: 10.
 	1 to: 10 do: [ :idx |
-			self
-				assert: (sieve originalIndexMap at: idx)
-				equals: (list dataSource at: idx) ].
-
+		self
+			assert: (sieve originalIndexMap at: idx)
+			equals: (list dataSource at: idx) ].
 ]
 
 { #category : #'tests - selection' }
 ToListElementSieveTest >> testSelectionViaList [
 	" the selecter can be used to select item programatically "
 
-	list dataAccessor addAll: self statesOfAmerica.
-	list selecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: self statesOfAmerica ].
+	space deferAndSettle: [ list selecter selectOneMoreIndex: 3 ].
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
-	sieve pattern: 'Alabama'.
+
+	space deferAndSettle: [ sieve pattern: 'Alabama' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list dataAccessor size equals: 1.
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
 	self assert: list selectionModel selectedIndexes equals: #(  ).
-	sieve pattern: ''.
+
+	space deferAndSettle: [ sieve pattern: '' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
 	self assert: list selectionModel selectedIndexes equals: #( 3 )
 ]
@@ -269,27 +269,30 @@ ToListElementSieveTest >> testSelectionViaList [
 ToListElementSieveTest >> testSelectionViaList2 [
 	" the selecter can be used to select item programatically "
 
-	list dataAccessor addAll: self statesOfAmerica.
+	space deferAndSettle: [ list dataAccessor addAll: self statesOfAmerica ].
 	" select California, Colorado and Connecticut "
-	list selecter selectIndex: 5 to: 7.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list selecter selectIndex: 5 to: 7 ].
 	self assert: sieve selectionModel selectedIndexes equals: #( 5 6 7 ).
-	sieve pattern: 'Alabama'.
+
+	space deferAndSettle: [ sieve pattern: 'Alabama' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes equals: #(  ).
-	sieve pattern: 'C'.
+
+	space deferAndSettle: [ sieve pattern: 'C' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list selectionModel selectedIndexes equals: #( 1 2 3 ).
-	sieve pattern: 'Co'.
+
+	space deferAndSettle: [ sieve pattern: 'Co' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list selectionModel selectedIndexes equals: #( 1 2 ).
-	sieve pattern: 'Col'.
+
+	space deferAndSettle: [ sieve pattern: 'Col' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list selectionModel selectedIndexes equals: #( 1 ).
 	self assert: list dataAccessor size equals: 1.
 	self assert: list dataAccessor first equals: 'Colorado'
@@ -299,19 +302,20 @@ ToListElementSieveTest >> testSelectionViaList2 [
 ToListElementSieveTest >> testSelectionViaSelecter [
 	" the selecter can be used to select item programatically "
 
-	list dataAccessor addAll: self statesOfAmerica.
-	sieve selecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: self statesOfAmerica ].
+	space deferAndSettle: [ sieve selecter selectOneMoreIndex: 3 ].
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
-	sieve pattern: 'Alabama'.
+
+	space deferAndSettle: [ sieve pattern: 'Alabama' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: list dataAccessor size equals: 1.
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
 	self assert: list selectionModel selectedIndexes equals: #(  ).
-	sieve pattern: ''.
+
+	space deferAndSettle: [ sieve pattern: '' ].
 	500 milliSeconds wait.
-	self waitTestingSpaces.
+	space settle.
 	self assert: sieve selectionModel selectedIndexes equals: #( 3 ).
 	self assert: list selectionModel selectedIndexes equals: #( 3 )
 ]

--- a/src/Toplo-Widget-List-Tests/ToListElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToListElementTest.class.st
@@ -12,7 +12,7 @@ ToListElementTest >> listWithRemoveRowButtons [
 
 	| list |
 	list := ToListElement new.
-	space root addChild: list.
+	space deferAndSettle: [ space root addChild: list ].
 	list nodeBuilder: [ :node :dataItem :holder |
 		| line remBut filler |
 		line := ToPane horizontal id: #row.
@@ -43,7 +43,7 @@ ToListElementTest >> statesOfAmerica [
 		#'New York'. #'North Carolina'. #'North Dakota'. #Ohio. #Oklahoma.
 		#Oregon. #'Pennsylvania Rhode Island'. #'South Carolina'.
 		#'South Dakota'. #Tennessee. #Texas. #Utah. #Vermont. #Virginia.
-		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }.
+		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -52,21 +52,19 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterInsert [
 	| l |
 	l := ToListElement new.
 	l useCheckbox: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
-	l forceLayout.
-	self applyAllEnqueuedStates.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Needs to be in a separate block to let layout build node containers before selection"
+	space deferAndSettle: [
+		l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 4 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
+	self assert: (l nodeContainers third) checkbox isChecked.
 
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1  ].
+	self assert: l selectionModel selectedIndexes equals: { 4 }.
+	self deny: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -76,24 +74,21 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterInsert1 [
 	l := ToListElement new.
 	l matchParent.
 	l useCheckbox: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self assert: l nodeContainers third checkbox isChecked.
 	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10).
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10) ].
 	self assert: l dataAccessor size equals: 10.
 	self assert: (l selectionModel selectedIndexes) equals: { 8 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 8) checkbox isChecked.
-
+	self deny: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers at: 8) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -103,25 +98,21 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterInsert2 [
 	l := ToListElement new.
 	l matchParent.
 	l useCheckbox: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self assert: l nodeContainers third checkbox isChecked.
 	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 6).
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l dataAccessor size equals: 6.
-	self waitTestingSpaces.
-	self assert: (l selectionModel selectedIndexes) equals: { 4 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
 
+	space deferAndSettle: [ l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 6)  ].
+	self assert: l dataAccessor size equals: 6.
+	self assert: (l selectionModel selectedIndexes) equals: { 4 }.
+	self deny: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -129,26 +120,23 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterInsert3 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l matchParent.
-	l useCheckbox: true.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l matchParent.
+		l useCheckbox: true.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
-	l forceLayout.
-	self applyAllEnqueuedStates.
-	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: #( 4 5 ).
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
-	self assert: (l nodeContainers at: 5) checkbox isChecked.
 
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
+	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
+	self assert: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked.
+
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1 ].
+	self assert: l selectionModel selectedIndexes equals: #( 4 5 ).
+	self deny: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked.
+	self assert: (l nodeContainers fifth) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -157,23 +145,19 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterInsert4 [
 	| l |
 	l := ToListElement new.
 	l useCheckbox: true.
-	space root addChild: l.
-	l matchParent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 1).
-	self waitTestingSpaces.
-	l forceLayout.
-	l selecter selectIndex: 1.
-	self waitTestingSpaces.
-	space applyAllEnqueuedStates.
+	space deferAndSettle: [
+		space root addChild: l.
+		l matchParent.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 1) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectIndex: 1 ].
 	self assert: l selectionModel selectedIndexes equals: { 1 }.
-	self assert: (l nodeContainers at: 1) checkbox isChecked.
-	l dataAccessor addFirst: (self statesOfAmerica at: 6).
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 2 }.
-	self deny: (l nodeContainers at: 1) checkbox isChecked.
-	self assert: (l nodeContainers at: 2) checkbox isChecked.
+	self assert: (l nodeContainers first) checkbox isChecked.
 
+	space deferAndSettle: [ l dataAccessor addFirst: (self statesOfAmerica at: 6) ].
+	self assert: l selectionModel selectedIndexes equals: { 2 }.
+	self deny: (l nodeContainers first) checkbox isChecked.
+	self assert: (l nodeContainers second) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -182,20 +166,18 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterRemove [
 	| l selectionElement |
 	l := ToListElement new.
 	l useCheckbox: true.
-	space root addChild: l.
 	l matchParent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	l dataAccessor removeAt: 2.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
+	self assert: (l nodeContainers third) checkbox isChecked.
 
-	self waitTestingSpaces.
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
-	self assert: (l nodeContainers at: 2) checkbox isChecked.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
+	self assert: (l nodeContainers second) checkbox isChecked.
+	self deny: (l nodeContainers third) checkbox isChecked.
 	self assert: l selectionOption selectionContainer children size equals: 1.
 	selectionElement := l selectionOption selectionContainer firstChild.
 	self assert: selectionElement bounds asRectangle equals: (selectionElement boundsInListElement: l)
@@ -207,20 +189,18 @@ ToListElementTest >> testCheckboxSelectionUpdatedAfterRemove2 [
 	| l selectionElement |
 	l := ToWrappedListElement new.
 	l useCheckbox: true.
-	space root addChild: l.
 	l matchParent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	l dataAccessor removeAt: 2.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
+	self assert: (l nodeContainers third) checkbox isChecked.
 
-	self waitTestingSpaces.
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
-	self assert: (l nodeContainers at: 2) checkbox isChecked.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
+	self assert: (l nodeContainers second) checkbox isChecked.
+	self deny: (l nodeContainers third) checkbox isChecked.
 	self assert: l selectionOption selectionContainer children size equals: 1.
 	selectionElement := l selectionOption selectionContainer firstChild.
 	self assert: selectionElement bounds asRectangle equals: (selectionElement boundsInListElement: l)
@@ -231,23 +211,22 @@ ToListElementTest >> testDataRemovedWhenNodeRemoved [
 
 	| list but remButtons fillers |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	list innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2)  ].
 	self assert: list dataAccessor size equals: 2.
 	self assert: list nodeContainers size equals: 2.
-	fillers := (list innerElement allChildrenBreadthFirstSelect: [ :child |
-		            child id asString = 'filler' ]) asOrderedCollection.
-	remButtons := (list innerElement allChildrenBreadthFirstSelect: [ :child |
-		               child id asString beginsWith: 'remove-button' ])
-		              asOrderedCollection.
+
+	fillers := (list innerElement
+		allChildrenBreadthFirstSelect: [ :child |
+			child id asString = 'filler' ]) asOrderedCollection.
+	remButtons := (list innerElement
+		allChildrenBreadthFirstSelect: [ :child |
+			child id asString beginsWith: 'remove-button' ]) asOrderedCollection.
 	" first click on the list to set the focus "
-	BlSpace simulateClickOn: fillers first.
+	fillers first eventSimulator click.
 	but := remButtons removeFirst.
-	BlSpace simulateClickOn: but.
-	self waitTestingSpaces.
+	but eventSimulator click.
 	but := remButtons removeFirst.
-	BlSpace simulateClickOn: but.
+	but eventSimulator click.
 	self assert: list dataAccessor isEmpty.
 	self assert:
 		list primarySelectionMode selectionOption selectionElements isEmpty
@@ -258,17 +237,17 @@ ToListElementTest >> testDisable [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l matchParent.
-	l dataAccessor addAll: { #A. #B. #C }.
-	self waitTestingSpaces.
-	l selecter selectOneMoreIndex: 2.
-	l secondarySelecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l matchParent.
+		l dataAccessor addAll: { #A. #B. #C } ].
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 2.
+		l secondarySelecter selectOneMoreIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
 	self assert: l secondarySelectionModel selectedIndexes equals: { 3 }.
-	l disable.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disable ].
 	self assert: l isDisabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
@@ -280,8 +259,8 @@ ToListElementTest >> testDisabledSelectionModel [
 
 	| l |
 	l := ToListElement new.
-	self assert: (l disabledSelectionMode selectionModel isKindOf:
-			 ToSubSelectionModel).
+	self assert:
+		(l disabledSelectionMode selectionModel isKindOf: ToSubSelectionModel).
 	self
 		assert: l disabledSelectionMode selectionModel
 		identicalTo: l disabledSelecter selectionModel.
@@ -295,11 +274,12 @@ ToListElementTest >> testDisabledSelectionModel2 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor addAll: { #A. #B. #C }.
-	self waitTestingSpaces.
-	l selecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: { #A. #B. #C } ].
+	"Must be in a separate block to let layout build node containers before selection"
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
 	self
 		assert: l disabledSelectionMode selectionModel
@@ -314,17 +294,18 @@ ToListElementTest >> testDisabledWithFiveNodes [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
-	l innerElement nodeContainers first holder disabled: true.
-	l dataAccessor addFirst: 'second'.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	l dataAccessor addFirst: 'fifth'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l innerElement nodeContainers first holder disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor addFirst: 'second' .
+		l dataAccessor add: 'third' .
+		l dataAccessor add: 'fourth' afterIndex: 2 .
+		l dataAccessor addFirst: 'fifth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }
 ]
 
@@ -333,16 +314,17 @@ ToListElementTest >> testDisabledWithFourNodes [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
-	l nodeContainers first disabled: true.
-	l dataAccessor addFirst: 'second'.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l nodeContainers first disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor addFirst: 'second' .
+		l dataAccessor add: 'third' .
+		l dataAccessor add: 'fourth' afterIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -351,17 +333,16 @@ ToListElementTest >> testDisabledWithFourNodes2 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	l dataAccessor add: 'second'.
-	self waitTestingSpaces.
-	l requestLayout.
-	l innerElement forceLayout.
-	self assert: l nodeContainers size equals: 2.
-	l nodeContainers second disabled: true.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth'.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l .
+		l dataAccessor add: 'first' .
+		l dataAccessor add: 'second' ].
+
+	space deferAndSettle: [
+		l nodeContainers second disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor add: 'third' .
+		l dataAccessor add: 'fourth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -370,14 +351,13 @@ ToListElementTest >> testDisabledWithOneNode [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l .
+		l dataAccessor add: 'first' ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1
 ]
 
@@ -386,21 +366,21 @@ ToListElementTest >> testDisabledWithThreeNodes [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first holder disabled: true.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [
+		l nodeContainers first holder disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: 'third'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: 'third' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -409,17 +389,17 @@ ToListElementTest >> testDisabledWithTwoNodes [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -429,17 +409,17 @@ ToListElementTest >> testDisabledWithTwoNodes2 [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first disabled: true.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [
+		l nodeContainers first disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second'  ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -449,18 +429,18 @@ ToListElementTest >> testDisabledWithTwoNodes3 [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first disabled: true.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l nodeContainers first disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
 	self assert: l nodeContainers first node isDisabled.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second'  ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -470,37 +450,34 @@ ToListElementTest >> testDoubleListsSelectionEvents [
 
 	| panel list1 list2 tabSize |
 	panel := ToPane new.
-	space root addChild: panel.
 	panel matchParent.
 	tabSize := 2.
 	list1 := ToListElement new.
 	list2 := ToListElement new.
-	1 to: tabSize do: [ :i |
-	list1 dataAccessor add: 'Hello ' , i asString ].
-	self waitTestingSpaces.
-	list1 innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: panel.
+		panel addChild: list1 .
+		panel addChild: list2 ].
+	space deferAndSettle: [ 
+		1 to: tabSize do: [ :i |
+			list1 dataAccessor add: 'Hello ' , i asString ] ].
 	self assert: list1 nodeContainers size equals: tabSize.
-	1 to: tabSize do: [ :i |
-	list2 dataAccessor add: 'Goodbye ' , i asString ].
-	self waitTestingSpaces.
-	list1 addEventHandler: (BlEventHandler
-			 on: ToListPrimarySelectionChangedEvent
-			 do: [ :e |
-					 list2 selecter deselectAll.
-					 e currentTarget selectionModel selectedIndexesDo: [ :idx |
-						 list2 selecter selectOneMoreIndex: idx ].
-					 self waitTestingSpaces ]).
-	panel addChild: list1.
-	panel addChild: list2.
-	self waitTestingSpaces.
-	list1 selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ 
+		1 to: tabSize do: [ :i |
+			list2 dataAccessor add: 'Goodbye ' , i asString ] ].
+		list1 addEventHandler: (BlEventHandler
+			on: ToListPrimarySelectionChangedEvent
+			do: [ :e |
+					list2 selecter deselectAll.
+					e currentTarget selectionModel selectedIndexesDo: [ :idx |
+						list2 selecter selectOneMoreIndex: idx ].
+					]).
+	space deferAndSettle: [ list1 selecter selectOneMoreIndex: 1 ].
 	self assert: (list1 selectionModel containsIndex: 1).
 	self assert: (list2 selectionModel containsIndex: 1).
 
-	list2 selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list2 selecter selectIndex: 2 ].
 	self assert: (list2 selectionModel containsIndex: 2)
 ]
 
@@ -525,12 +502,12 @@ ToListElementTest >> testEmptyListAddOrRemoveNextInSelection [
 
 	| l |
 	l := ToListElement new.
-
 	l fitContent.
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero
 ]
 
@@ -541,10 +518,12 @@ ToListElementTest >> testEmptyListAddOrRemovePreviousInSelection [
 	l := ToListElement new.
 	l fitContent.
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [
+		l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex isZero
 ]
 
@@ -553,15 +532,15 @@ ToListElementTest >> testEmptyListSelectNextInSelection [
 
 	| l |
 	l := ToListElement new.
-
 	l fitContent.
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty
 ]
@@ -571,13 +550,13 @@ ToListElementTest >> testEmptyListSelectPreviousInSelection [
 
 	| l |
 	l := ToListElement new.
-
 	l fitContent.
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: l selecter previousSelectableIndex .
+		l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
+		l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty
 ]
@@ -587,19 +566,20 @@ ToListElementTest >> testEnable [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-
-	l matchParent.
-	l dataAccessor addAll: { #A. #B. #C }.
-	l selecter selectOneMoreIndex: 2.
-	l secondarySelecter selectOneMoreIndex: 3.
-	l disable.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l matchParent.
+		l dataAccessor addAll: { #A. #B. #C } .
+		l selecter selectOneMoreIndex: 2 .
+		l secondarySelecter selectOneMoreIndex: 3 .
+		l disable.
+		space root addChild: l ].
 	self assert: l isDisabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
+
 	l nodeContainersDo: [ :container | self assert: container isDisabled ].
-	l enable.
+
+	space deferAndSettle: [ l enable ].
 	self assert: l isEnabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
@@ -611,8 +591,7 @@ ToListElementTest >> testHiddenSelectionModel [
 
 	| l |
 	l := ToListElement new.
-	self assert: (l hiddenSelectionMode selectionModel isKindOf:
-			 ToSubSelectionModel).
+	self assert: (l hiddenSelectionMode selectionModel isKindOf: ToSubSelectionModel).
 	self
 		assert: l hiddenSelectionMode selectionModel
 		identicalTo: l hiddenSelecter selectionModel.
@@ -627,7 +606,7 @@ ToListElementTest >> testListElementWithFiveDefaultSelectionMode [
 	| l |
 	l := ToListElement new.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5
 ]
 
@@ -636,22 +615,21 @@ ToListElementTest >> testMakeDisabledUnselectable [
 
 	| l |
 	l := ToListElement new.
-	l selectionMode makeDisabledUnselectable: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l disabledSelecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l selectionMode makeDisabledUnselectable: true .
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	space deferAndSettle: [
+		l disabledSelecter selectOneMoreIndex: 3 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l unselectableSelecter selectedIndexes equals: {  }.
-	l selecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 3 ].
 	self assert: l selecter selectedIndexes equals: {  }.
-	l selectionMode makeDisabledUnselectable: false.
-	l selecter selectIndex: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l selectionMode makeDisabledUnselectable: false .
+		l selecter selectIndex: 3 ].
 	self assert: l selecter selectedIndexes equals: { 3 }
 ]
 
@@ -660,32 +638,28 @@ ToListElementTest >> testNodeDeselectedWhenNodeRemoved [
 
 	| list fillers remButtons but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
+
 	remButtons := (list innerElement allChildrenBreadthFirstSelect: [ :child |
 		               child id asString beginsWith: 'remove-button' ])
 		              asOrderedCollection.
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
+		assert: list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
-	but := remButtons at: 2.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
+
+	but := remButtons second.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
+		assert: list primarySelectionMode selectionOption selectionElements size
 		equals: 1
 ]
 
@@ -694,25 +668,21 @@ ToListElementTest >> testNodeDeselectedWhenNodeRemoved2 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
+
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
+		assert: list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
+
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	self assert:
@@ -724,31 +694,27 @@ ToListElementTest >> testNodeDeselectedWhenNodeRemoved3 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
+
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
+		assert: list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
+
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes isEmpty.
+
 	but := list childWithId: #'remove-button-2'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 0.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	self assert:
@@ -760,31 +726,27 @@ ToListElementTest >> testNodeDeselectedWhenNodeRemoved4 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
+
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
+
 	but := list childWithId: #'remove-button-2'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
+		assert: list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
+
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 0.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	self assert:
@@ -797,13 +759,12 @@ ToListElementTest >> testPrimarySelectionChangedEventDispatch [
 
 	| l dispatchedEvent |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	l selecter selectOnlyIndex: 3.
-	" have to pulse space to get selection actually updated "
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self
 		assert: l selectionMode selectionContainer children size
@@ -812,9 +773,8 @@ ToListElementTest >> testPrimarySelectionChangedEventDispatch [
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
-	l dataAccessor removeAt: 3.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
+	"Must be in a separate block to let layout/event loop process selection before removal"
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
 	self assert: l selectionModel selectedIndexes equals: {  }.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
@@ -826,19 +786,18 @@ ToListElementTest >> testPrimarySelectionChangedEventDispatch1 [
 
 	| l dispatchedEvent |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	l
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
-	l dataAccessor removeAt: 3.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
+	"Must be in a separate block to let layout/event loop process selection before removal"
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
 	self assert: l selectionModel selectedIndexes equals: {  }.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
@@ -850,13 +809,12 @@ ToListElementTest >> testPrimarySelectionChangedEventDispatchAfterRemoveAll [
 
 	| l dispatchedEvent |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	l selecter selectOnlyIndex: 3.
-	" have to pulse space to get selection actually updated "
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self
 		assert: l selectionMode selectionContainer children size
@@ -866,9 +824,8 @@ ToListElementTest >> testPrimarySelectionChangedEventDispatchAfterRemoveAll [
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	l dataAccessor removeAll.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAll ].
 	self assert: l selectionModel selectedIndexes equals: {  }.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
@@ -879,17 +836,16 @@ ToListElementTest >> testRemoveAll [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l innerElement extent: 800 @ 600.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 5.
-	l selecter selectOnlyIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 2 ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 ).
-	l dataAccessor removeAll.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAll ].
 	self assert: l nodeContainers size equals: 0.
 	self assert: l selectionModel selectedIndexes isEmpty
 ]
@@ -899,28 +855,29 @@ ToListElementTest >> testSelectAndScrollToNext [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [
+		space root addChild: l.
+		l fitContent.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l forceLayout.
-	l selecter selectOneMoreIndex: 4.
-	l selecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 4 .
+		l selecter selectOneMoreIndex: 2 ].
 	self assert: l selecter currentIndex equals: 2.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 2 4 ).
-	l selecter selectIndex: l selecter nextSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter nextSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 3.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 2 3 4 ).
-	l selecter selectIndex: l selecter nextSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter nextSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 4.
 	self
 		assert: l selectionModel selectedIndexes asArray
@@ -932,26 +889,25 @@ ToListElementTest >> testSelectAndScrollToPrevious [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5)  ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOneMoreIndex: 4.
-	self waitTestingSpaces.
-	l forceLayout.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 4 ].
 	self assert: l selecter currentIndex equals: 4.
 	self assert: l selectionModel selectedIndexes asArray equals: #( 4 ).
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 3.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 3 4 ).
-	l selecter selectIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 2.
 	self
 		assert: l selectionModel selectedIndexes asArray
@@ -964,17 +920,16 @@ ToListElementTest >> testSelectionAfterLastRemoval [
 	| l |
 	l := ToListElement new.
 	l secondarySelectionMode selecter enabled: false.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 5 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 5 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 5 ).
-	self waitTestingSpaces.
-	l dataAccessor removeAt: 5.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 5 ].
 	self assert: l selectionModel selectedIndexes equals: #(  )
 ]
 
@@ -983,16 +938,16 @@ ToListElementTest >> testSelectionUpdatedAfterInsert [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l selecter selectOnlyIndex: 3 ].
 	self assert: l selecter currentIndex equals: 3.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1 ].
 	self assert: l selecter currentIndex equals: 3.
-	self waitTestingSpaces.
 	self assert: l selectionModel lastIndex equals: 4
 ]
 
@@ -1001,19 +956,18 @@ ToListElementTest >> testSelectionUpdatedAfterInsert1 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self assert: l selecter currentIndex equals: 3.
-	l forceLayout.
 	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10).
+
+	space deferAndSettle: [ l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10) ].
 	self assert: l dataAccessor size equals: 10.
-	self waitTestingSpaces.
 	self assert: l nodeContainers size equals: 10.
 	self assert: l selectionModel lastIndex equals: 8
 ]
@@ -1023,19 +977,19 @@ ToListElementTest >> testSelectionUpdatedAfterInsert3 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
 	self assert: l selecter currentIndex equals: 4.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
+
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica copyFrom: 6 to: 6) afterIndex: 1 ].
 	self assert: l selecter currentIndex equals: 4.
 	self assert: l selecter currentIndex equals: 4.
-	self waitTestingSpaces.
 	self assert: l selectionModel selectedIndexes equals: #( 4 5 )
 ]
 
@@ -1044,15 +998,14 @@ ToListElementTest >> testSelectionUpdatedAfterRemove [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
-	l dataAccessor removeAt: 2.
-
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
+	"Must be in a separate block to let layout/event loop process selection before removal"
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }
 ]
 
@@ -1061,15 +1014,15 @@ ToListElementTest >> testSelectionUpdatedAfterRemove1 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	l dataAccessor removeAll.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAll ].
 	self assert: l dataAccessor size equals: 0.
 	self assert: l selectionModel isEmpty
 ]
@@ -1079,16 +1032,16 @@ ToListElementTest >> testSelectionUpdatedAfterRemove2 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	self waitTestingSpaces.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selecter currentIndex equals: 3.
-	l dataAccessor removeAt: 4.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 4 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }
 ]
 
@@ -1097,17 +1050,16 @@ ToListElementTest >> testSelectionUpdatedAfterRemove3 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 2.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 3 )
 ]
 
@@ -1116,19 +1068,18 @@ ToListElementTest >> testSelectionUpdatedAfterRemove4 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 2 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 2 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 ).
-	l dataAccessor removeAt: 2.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes isEmpty
+
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
+	self assert: l selectionModel selectedIndexes equals: {  }
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -1136,17 +1087,16 @@ ToListElementTest >> testSelectionUpdatedAfterRemove5 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 )
 ]
 
@@ -1155,19 +1105,19 @@ ToListElementTest >> testSelectionUpdatedAfterRemove6 [
 
 	| l |
 	l := ToListElement new.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 3.
-	l dataAccessor removeAt: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: #(  )
+
+	space deferAndSettle: [
+		l dataAccessor removeAt: 3.
+		l dataAccessor removeAt: 3 ].
+	self assert: l selectionModel selectedIndexes equals: {  }
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -1176,14 +1126,13 @@ ToListElementTest >> testSelectionWithOneNode [
 	| l |
 	l := ToListElement new.
 	l dataAccessor removeAll.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
 	self assert: l selectionModel selectedIndexes equals: { 1 }
 ]
@@ -1193,16 +1142,16 @@ ToListElementTest >> testSelectionWithTwoNodes [
 
 	| l |
 	l := ToListElement new.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first' .
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second'  ].
 	self assert: l selecter selectedIndex equals: 2.
 	self assert: l selecter selectedIndexes equals: { 2 }
 ]
@@ -1212,8 +1161,7 @@ ToListElementTest >> testUnselectableSelectionModel [
 
 	| l |
 	l := ToListElement new.
-	self assert: (l unselectableSelectionMode selectionModel isKindOf:
-			 ToSubSelectionModel).
+	self assert: (l unselectableSelectionMode selectionModel isKindOf: ToSubSelectionModel).
 	self
 		assert: l unselectableSelectionMode selectionModel
 		identicalTo: l unselectableSelecter selectionModel.

--- a/src/Toplo-Widget-List-Tests/ToListElementWithFakeNodeContainerTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToListElementWithFakeNodeContainerTest.class.st
@@ -10,11 +10,10 @@ ToListElementWithFakeNodeContainerTest >> testOneSpecifcNode [
 	| l |
 	l := ToListElementWithFakeNodeContainerForTest new.
 	l dataAccessor add: 'first'.
-	self waitTestingSpaces.
 	self assert: l dataSource first equals: 'first'.
+
 	" adding the list in the space consequence is a layout computing which update the list nodes"
-	space root addChild: l.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l nodeContainers first node class identicalTo: ToListNodeForTest.	
 	self assert: l nodeContainers first holder class identicalTo: ToListNodeHolderForTest.	

--- a/src/Toplo-Widget-List-Tests/ToListElementWithFiniteInnerElementTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToListElementWithFiniteInnerElementTest.class.st
@@ -12,7 +12,7 @@ ToListElementWithFiniteInnerElementTest >> listWithRemoveRowButtons [
 
 	| list |
 	list := ToListElement finite.
-	space root addChild: list.
+	space deferAndSettle: [ space root addChild: list ].
 	list nodeBuilder: [ :node :dataItem :holder |
 		| line remBut filler |
 		line := ToPane horizontal id: #row.
@@ -43,7 +43,7 @@ ToListElementWithFiniteInnerElementTest >> statesOfAmerica [
 		#'New York'. #'North Carolina'. #'North Dakota'. #Ohio. #Oklahoma.
 		#Oregon. #'Pennsylvania Rhode Island'. #'South Carolina'.
 		#'South Dakota'. #Tennessee. #Texas. #Utah. #Vermont. #Virginia.
-		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }.
+		#Washington. #'West Virginia'. #Wisconsin. #Wyoming }
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -52,23 +52,19 @@ ToListElementWithFiniteInnerElementTest >> testCheckboxSelectionUpdatedAfterInse
 	| l |
 	l := ToListElement finite.
 	l useCheckbox: true.
-	space root addChild: l.
-	self waitTestingSpaces.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
-	self assert: l selectionModel selectedIndexes equals: { 4 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
+	space deferAndSettle: [
+		space root addChild: l .
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Needs to be in a separate block"
+	space deferAndSettle: [
+		l selecter selectOnlyIndex: 3 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 3 }.
+	self assert: ((l nodeContainers third) checkbox isChecked).
 
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 4 }.
+	self deny: ((l nodeContainers third) checkbox isChecked).
+	self assert: ((l nodeContainers fourth) checkbox isChecked)
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -78,24 +74,22 @@ ToListElementWithFiniteInnerElementTest >> testCheckboxSelectionUpdatedAfterInse
 	l := ToListElement finite.
 	l matchParent.
 	l useCheckbox: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	self assert: l nodeContainers third checkbox isChecked.
-	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10).
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l dataAccessor size equals: 10.
-	self waitTestingSpaces.
-	self assert: (l selectionModel selectedIndexes) equals: { 8 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 8) checkbox isChecked.
+	space deferAndSettle: [
+		space root addChild: l .
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	self assert: (l dataAccessor size) equals: 5.
 
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 3 }.
+	self assert: (l nodeContainers third checkbox isChecked).
+	self assert: (l nodeContainers size) equals: 5.
+
+	space deferAndSettle: [
+		l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10) ].
+	self assert: (l dataAccessor size) equals: 10.
+	self assert: (l selectionModel selectedIndexes) equals: { 8 }.
+	self deny: ((l nodeContainers third) checkbox isChecked).
+	self assert: ((l nodeContainers at: 8) checkbox isChecked)
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -105,24 +99,22 @@ ToListElementWithFiniteInnerElementTest >> testCheckboxSelectionUpdatedAfterInse
 	l := ToListElement finite.
 	l matchParent.
 	l useCheckbox: true.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	self assert: l nodeContainers third checkbox isChecked.
-	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 6).
-	l forceLayout.
-	self waitTestingSpaces.
-	self assert: l dataAccessor size equals: 6.
-	self waitTestingSpaces.
-	self assert: (l selectionModel selectedIndexes) equals: { 4 }.
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
+	space deferAndSettle: [
+		space root addChild: l .
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	self assert: (l dataAccessor size) equals: 5.
 
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 3 }.
+	self assert: (l nodeContainers third checkbox isChecked).
+	self assert: (l nodeContainers size) equals: 5.
+
+	space deferAndSettle: [
+		l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 6) ].
+	self assert: (l dataAccessor size) equals: 6.
+	self assert: (l selectionModel selectedIndexes) equals: { 4 }.
+	self deny: ((l nodeContainers third) checkbox isChecked).
+	self assert: ((l nodeContainers fourth) checkbox isChecked)
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -130,27 +122,23 @@ ToListElementWithFiniteInnerElementTest >> testCheckboxSelectionUpdatedAfterInse
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l useCheckbox: true.
-	self waitTestingSpaces.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selectionModel isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
-	l forceLayout.
-	self applyAllEnqueuedStates.
-	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	self assert: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
-	self assert: l selectionModel selectedIndexes equals: #( 4 5 ).
-	self deny: (l nodeContainers at: 3) checkbox isChecked.
-	self assert: (l nodeContainers at: 4) checkbox isChecked.
-	self assert: (l nodeContainers at: 5) checkbox isChecked.
 
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
+	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
+	self assert: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked.
+
+	space deferAndSettle: [
+		l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1 ].
+	self assert: l selectionModel selectedIndexes equals: #( 4 5 ).
+	self deny: (l nodeContainers third) checkbox isChecked.
+	self assert: (l nodeContainers fourth) checkbox isChecked.
+	self assert: (l nodeContainers fifth) checkbox isChecked
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -159,24 +147,19 @@ ToListElementWithFiniteInnerElementTest >> testCheckboxSelectionUpdatedAfterInse
 	| l |
 	l := ToListElement finite.
 	l useCheckbox: true.
-	space root addChild: l.
 	l matchParent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 1).
-	self waitTestingSpaces.
-	l forceLayout.
-	l selecter selectIndex: 1.
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
-	l forceLayout.
-	self assert: l selectionModel selectedIndexes equals: { 1 }.
-	self assert: (l nodeContainers at: 1) checkbox isChecked.
-	l dataAccessor addFirst: (self statesOfAmerica at: 6).
-	self waitTestingSpaces.
-	self applyAllEnqueuedStates.
-	self assert: l selectionModel selectedIndexes equals: { 2 }.
-	self deny: (l nodeContainers at: 1) checkbox isChecked.
-	self assert: (l nodeContainers at: 2) checkbox isChecked.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 1) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectIndex: 1 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 1 }.
+	self assert: ((l nodeContainers first) checkbox isChecked).
 
+	space deferAndSettle: [ l dataAccessor addFirst: (self statesOfAmerica at: 6) ].
+	self assert: (l selectionModel selectedIndexes) equals: { 2 }.
+	self deny: ((l nodeContainers first) checkbox isChecked).
+	self assert: ((l nodeContainers second) checkbox isChecked)
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -184,26 +167,20 @@ ToListElementWithFiniteInnerElementTest >> testDataRemovedWhenNodeRemoved [
 
 	| list but remButtons fillers |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	list innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
 	self assert: list nodeContainers size equals: 2.
 	fillers := (list innerElement allChildrenBreadthFirstSelect: [ :child |
-		            child id asString = 'filler' ]) asOrderedCollection.
+		child id asString = 'filler' ]) asOrderedCollection.
 	remButtons := (list innerElement allChildrenBreadthFirstSelect: [ :child |
-		               child id asString beginsWith: 'remove-button' ])
-		              asOrderedCollection.
-	" first click on the list to set the focus "
-	BlSpace simulateClickOn: fillers first.
+		child id asString beginsWith: 'remove-button' ]) asOrderedCollection.
+	fillers first eventSimulator click.
 	but := remButtons removeFirst.
-	BlSpace simulateClickOn: but.
-	self waitTestingSpaces.
+	but eventSimulator click.
 	but := remButtons removeFirst.
-	BlSpace simulateClickOn: but.
+	but eventSimulator click.
 	self assert: list dataAccessor isEmpty.
-	self assert:
-		list primarySelectionMode selectionOption selectionElements isEmpty
+	self assert: list primarySelectionMode selectionOption selectionElements isEmpty
 ]
 
 { #category : #'test selection - mode' }
@@ -211,16 +188,17 @@ ToListElementWithFiniteInnerElementTest >> testDisable [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l matchParent.
 	l dataAccessor addAll: { #A. #B. #C }.
-	l selecter selectOneMoreIndex: 2.
-	l secondarySelecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 2.
+		l secondarySelecter selectOneMoreIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
 	self assert: l secondarySelectionModel selectedIndexes equals: { 3 }.
-	l disable.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disable ].
 	self assert: l isDisabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
@@ -247,10 +225,12 @@ ToListElementWithFiniteInnerElementTest >> testDisabledSelectionModel2 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-	l dataAccessor addAll: { #A. #B. #C }.
-	l selecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: { #A. #B. #C } ].
+	"Must be in a separate block to let layout build node containers before selection"
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }.
 	self
 		assert: l disabledSelectionMode selectionModel
@@ -265,17 +245,17 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithFiveNodes [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
-	l innerElement nodeContainers first holder disabled: true.
-	l dataAccessor addFirst: 'second'.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	l dataAccessor addFirst: 'fifth'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l innerElement nodeContainers first holder disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor addFirst: 'second'.
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' afterIndex: 2.
+		l dataAccessor addFirst: 'fifth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }
 ]
 
@@ -284,16 +264,16 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithFourNodes [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
-	l nodeContainers first disabled: true.
-	l dataAccessor addFirst: 'second'.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth' afterIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l nodeContainers first disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor addFirst: 'second'.
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' afterIndex: 2 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -302,17 +282,16 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithFourNodes2 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	l dataAccessor add: 'second'.
-	self waitTestingSpaces.
-	l requestLayout.
-	l innerElement forceLayout.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor add: 'first'.
+		l dataAccessor add: 'second' ].
 	self assert: l nodeContainers size equals: 2.
-	l nodeContainers second disabled: true.
-	l dataAccessor add: 'third'.
-	l dataAccessor add: 'fourth'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l nodeContainers second disabled: true ].
+	space deferAndSettle: [
+		l dataAccessor add: 'third'.
+		l dataAccessor add: 'fourth' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -321,14 +300,13 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithOneNode [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-	l dataAccessor add: 'first'.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor add: 'first' ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1
 ]
 
@@ -337,21 +315,20 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithThreeNodes [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first holder disabled: true.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l nodeContainers first holder disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }.
-	l dataAccessor add: 'third'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor add: 'third' ].
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
 
@@ -360,17 +337,16 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithTwoNodes [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l disabledSelecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 1 ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -380,17 +356,16 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithTwoNodes2 [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first disabled: true.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l nodeContainers first disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -400,18 +375,17 @@ ToListElementWithFiniteInnerElementTest >> testDisabledWithTwoNodes3 [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l nodeContainers size equals: 1.
 	self assert: l disabledSelectionModel isEmpty.
-	l nodeContainers first disabled: true.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l nodeContainers first disabled: true ].
 	self assert: l disabledSelecter selectedIndex equals: 1.
 	self assert: l nodeContainers first node isDisabled.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l disabledSelecter selectedIndex equals: 2.
 	self assert: l disabledSelecter selectedIndexes equals: { 2 }
 ]
@@ -421,35 +395,33 @@ ToListElementWithFiniteInnerElementTest >> testDoubleListsSelectionEvents [
 
 	| panel list1 list2 tabSize |
 	panel := ToPane new.
-	space root addChild: panel.
+	space deferAndSettle: [ space root addChild: panel ].
 	panel matchParent.
 	tabSize := 2.
 	list1 := ToListElement finite.
 	list2 := ToListElement finite.
 	1 to: tabSize do: [ :i |
-	list1 dataAccessor add: 'Hello ' , i asString ].
-	list1 innerElement forceLayout.
-	self waitTestingSpaces.
+		space deferAndSettle: [ list1 dataAccessor add: 'Hello ' , i asString ] ].
 	self assert: list1 nodeContainers size equals: tabSize.
 	1 to: tabSize do: [ :i |
-	list2 dataAccessor add: 'Goodbye ' , i asString ].
+		space deferAndSettle: [ list2 dataAccessor add: 'Goodbye ' , i asString ] ].
 
 	list1 addEventHandler: (BlEventHandler
-			 on: ToListPrimarySelectionChangedEvent
-			 do: [ :e |
-					 list2 selecter deselectAll.
-					 e currentTarget selectionModel selectedIndexesDo: [ :idx |
-						 list2 selecter selectOneMoreIndex: idx ].
-					 self waitTestingSpaces ]).
-	panel addChild: list1.
-	panel addChild: list2.
-	list1 selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		on: ToListPrimarySelectionChangedEvent
+		do: [ :e |
+			list2 selecter deselectAll.
+			e currentTarget selectionModel selectedIndexesDo: [ :idx |
+				list2 selecter selectOneMoreIndex: idx ] ]).
+	space deferAndSettle: [
+		panel addChild: list1.
+		panel addChild: list2 ].
+	"Must be in a separate block to let layout attach lists before selection"
+	space deferAndSettle: [
+		list1 selecter selectOneMoreIndex: 1 ].
 	self assert: (list1 selectionModel containsIndex: 1).
 	self assert: (list2 selectionModel containsIndex: 1).
 
-	list2 selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list2 selecter selectIndex: 2 ].
 	self assert: (list2 selectionModel containsIndex: 2)
 ]
 
@@ -474,12 +446,12 @@ ToListElementWithFiniteInnerElementTest >> testEmptyListAddOrRemoveNextInSelecti
 
 	| l |
 	l := ToListElement finite.
-
 	l fitContent.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero
 ]
 
@@ -489,11 +461,12 @@ ToListElementWithFiniteInnerElementTest >> testEmptyListAddOrRemovePreviousInSel
 	| l |
 	l := ToListElement finite.
 	l fitContent.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex isZero
 ]
 
@@ -502,15 +475,16 @@ ToListElementWithFiniteInnerElementTest >> testEmptyListSelectNextInSelection [
 
 	| l |
 	l := ToListElement finite.
-
 	l fitContent.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: l selecter nextSelectableIndex.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter nextSelectableIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty
 ]
@@ -520,13 +494,15 @@ ToListElementWithFiniteInnerElementTest >> testEmptyListSelectPreviousInSelectio
 
 	| l |
 	l := ToListElement finite.
-
 	l fitContent.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor isEmpty.
-	l forceLayout.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
+	self assert: l selectionModel isEmpty.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
+		l selecter selectOneMoreIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex isZero.
 	self assert: l selectionModel isEmpty
 ]
@@ -536,19 +512,21 @@ ToListElementWithFiniteInnerElementTest >> testEnable [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-
+	space deferAndSettle: [ space root addChild: l ].
 	l matchParent.
-	l dataAccessor addAll: { #A. #B. #C }.
-	l selecter selectOneMoreIndex: 2.
-	l secondarySelecter selectOneMoreIndex: 3.
-	l disable.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l dataAccessor addAll: { #A. #B. #C } ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 2.
+		l secondarySelecter selectOneMoreIndex: 3 ].
+	"Must be in a separate block to let layout process selection before disablement"
+	space deferAndSettle: [ l disable ].
 	self assert: l isDisabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
 	l nodeContainersDo: [ :container | self assert: container isDisabled ].
-	l enable.
+
+	space deferAndSettle: [ l enable ].
 	self assert: l isEnabled.
 	self assert: l selectionModel isEmpty.
 	self assert: l secondarySelectionModel isEmpty.
@@ -576,7 +554,7 @@ ToListElementWithFiniteInnerElementTest >> testListElementWithFiveDefaultSelecti
 	| l |
 	l := ToListElement finite.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5
 ]
 
@@ -586,20 +564,18 @@ ToListElementWithFiniteInnerElementTest >> testMakeDisabledUnselectable [
 	| l |
 	l := ToListElement finite.
 	l selectionMode makeDisabledUnselectable: true.
-	space root addChild: l.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l disabledSelecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
+	space deferAndSettle: [ l disabledSelecter selectOneMoreIndex: 3 ].
 	self assert: l disabledSelecter selectedIndexes equals: { 3 }.
 	self assert: l unselectableSelecter selectedIndexes equals: {  }.
-	l selecter selectOneMoreIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 3 ].
 	self assert: l selecter selectedIndexes equals: {  }.
-	l selectionMode makeDisabledUnselectable: false.
-	l selecter selectIndex: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l selectionMode makeDisabledUnselectable: false .
+		l selecter selectIndex: 3 ].
 	self assert: l selecter selectedIndexes equals: { 3 }
 ]
 
@@ -608,27 +584,23 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved [
 
 	| list fillers remButtons but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
 	remButtons := (list innerElement allChildrenBreadthFirstSelect: [ :child |
 		               child id asString beginsWith: 'remove-button' ])
 		              asOrderedCollection.
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
 		assert:
 		list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
-	but := remButtons at: 2.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
+	but := remButtons second.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
@@ -642,15 +614,11 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved2 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
@@ -658,9 +626,8 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved2 [
 		list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	self assert:
@@ -672,15 +639,11 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved3 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
 	self assert: list dataAccessor size equals: 2.
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 2.
 	self assert: list selectionModel selectedIndexes equals: { 1 }.
 	self
@@ -688,15 +651,13 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved3 [
 		list primarySelectionMode selectionOption selectionElements size
 		equals: 1.
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 1.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	but := list childWithId: #'remove-button-2'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
 	self assert: list dataAccessor size equals: 0.
 	self assert: list selectionModel selectedIndexes isEmpty.
 	self assert:
@@ -708,35 +669,31 @@ ToListElementWithFiniteInnerElementTest >> testNodeDeselectedWhenNodeRemoved4 [
 
 	| list fillers but |
 	list := self listWithRemoveRowButtons.
-	list dataAccessor addAll: (1 to: 2).
-	space applyAllSkinInstallers.
-	space root forceLayout.
-	self waitTestingSpaces.
-	self assert: list dataAccessor size equals: 2.
+	space deferAndSettle: [ list dataAccessor addAll: (1 to: 2) ].
+	self assert: (list dataAccessor size) equals: 2.
 	fillers := (list selectChildrenWithId: #filler) asOrderedCollection.
-	BlSpace simulateMouseDownOn: fillers first.
-	BlSpace simulateMouseUpOn: fillers first.
-	self waitTestingSpaces.
-	self assert: list dataAccessor size equals: 2.
-	self assert: list selectionModel selectedIndexes equals: { 1 }.
+	
+	fillers first eventSimulator mouseDown.
+	fillers first eventSimulator mouseUp.
+		
+	self assert: (list dataAccessor size) equals: 2.
+	self assert: (list selectionModel selectedIndexes) equals: { 1 }.
+	
 	but := list childWithId: #'remove-button-2'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
-	self assert: list dataAccessor size equals: 1.
-	self assert: list selectionModel selectedIndexes equals: { 1 }.
-	self
-		assert:
-		list primarySelectionMode selectionOption selectionElements size
-		equals: 1.
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
+		
+	self assert: (list dataAccessor size) equals: 1.
+	self assert: (list selectionModel selectedIndexes) equals: { 1 }.
+	self assert: (list primarySelectionMode selectionOption selectionElements size) equals: 1.
+	
 	but := list childWithId: #'remove-button-1'.
-	BlSpace simulateMouseDownOn: but.
-	BlSpace simulateMouseUpOn: but.
-	self waitTestingSpaces.
-	self assert: list dataAccessor size equals: 0.
-	self assert: list selectionModel selectedIndexes isEmpty.
-	self assert:
-		list primarySelectionMode selectionOption selectionElements isEmpty
+	but eventSimulator mouseDown.
+	but eventSimulator mouseUp.
+		
+	self assert: (list dataAccessor size) equals: 0.
+	self assert: (list selectionModel selectedIndexes isEmpty).
+	self assert: (list primarySelectionMode selectionOption selectionElements isEmpty)
 ]
 
 { #category : #'test - selection changed event' }
@@ -745,27 +702,25 @@ ToListElementWithFiniteInnerElementTest >> testPrimarySelectionChangedEventDispa
 
 	| l dispatchedEvent |
 	l := ToListElement finite.
-	space root addChild: l.
-	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	self waitTestingSpaces.
-	l selecter selectOnlyIndex: 3.
-	" have to pulse space to get selection actually updated "
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l fitContent.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self
 		assert: l selectionMode selectionContainer children size
 		equals: 1.
+
 	l
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
-	l dataAccessor removeAt: 3.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: {  }.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
+	self assert: l selectionModel selectedIndexes equals: { }.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
 ]
@@ -776,21 +731,17 @@ ToListElementWithFiniteInnerElementTest >> testPrimarySelectionChangedEventDispa
 
 	| l dispatchedEvent |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
 	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	l
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
-	l dataAccessor removeAt: 3.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
+	" we get an updated datasource plus oupdated selection model "
 	self assert: l selectionModel selectedIndexes equals: {  }.
-	self waitTestingSpaces.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
 ]
@@ -801,25 +752,24 @@ ToListElementWithFiniteInnerElementTest >> testPrimarySelectionChangedEventDispa
 
 	| l dispatchedEvent |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	l selecter selectOnlyIndex: 3.
-	" have to pulse space to get selection actually updated "
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self
 		assert: l selectionMode selectionContainer children size
 		equals: 1.
+
 	l
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | dispatchedEvent := event ].
 	dispatchedEvent := nil.
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	l dataAccessor removeAll.
-	" have to pulse to get an updated datasource plus oupdated selection model "
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAll ].
 	self assert: l selectionModel selectedIndexes equals: {  }.
 	self assert: l selectionMode selectionContainer children isEmpty.
 	self assert: dispatchedEvent notNil
@@ -830,17 +780,16 @@ ToListElementWithFiniteInnerElementTest >> testRemoveAll [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l innerElement extent: 800 @ 600.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l nodeContainers size equals: 5.
-	l selecter selectOnlyIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 2 ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 ).
-	l dataAccessor removeAll.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [ l dataAccessor removeAll ].
 	self assert: l nodeContainers size equals: 0.
 	self assert: l selectionModel selectedIndexes isEmpty
 ]
@@ -850,28 +799,28 @@ ToListElementWithFiniteInnerElementTest >> testSelectAndScrollToNext [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
+	space deferAndSettle: [ space root addChild: l ].
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l forceLayout.
-	l selecter selectOneMoreIndex: 4.
-	l selecter selectOneMoreIndex: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l selecter selectOneMoreIndex: 4.
+		l selecter selectOneMoreIndex: 2 ].
 	self assert: l selecter currentIndex equals: 2.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 2 4 ).
-	l selecter selectIndex: l selecter nextSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter nextSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 3.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 2 3 4 ).
-	l selecter selectIndex: l selecter nextSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter nextSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 4.
 	self
 		assert: l selectionModel selectedIndexes asArray
@@ -883,25 +832,24 @@ ToListElementWithFiniteInnerElementTest >> testSelectAndScrollToPrevious [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
+	space deferAndSettle: [ space root addChild: l ].
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOneMoreIndex: 4.
-	self waitTestingSpaces.
-	l forceLayout.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 4 ].
 	self assert: l selecter currentIndex equals: 4.
 	self assert: l selectionModel selectedIndexes asArray equals: #( 4 ).
-	l selecter selectOneMoreIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 3.
 	self
 		assert: l selectionModel selectedIndexes asArray
 		equals: #( 3 4 ).
-	l selecter selectIndex: l selecter previousSelectableIndex.
-	l selecter scrollToDataSourcePosition: l selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndex: l selecter previousSelectableIndex ].
+	space deferAndSettle: [ l selecter scrollToDataSourcePosition: l selecter currentIndex ].
 	self assert: l selecter currentIndex equals: 2.
 	self
 		assert: l selectionModel selectedIndexes asArray
@@ -914,16 +862,15 @@ ToListElementWithFiniteInnerElementTest >> testSelectionAfterLastRemoval [
 	| l |
 	l := ToListElement finite.
 	l secondarySelectionMode selecter enabled: false.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 5 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 5 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 5 ).
-	self waitTestingSpaces.
-	l dataAccessor removeAt: 5.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 5 ].
 	self assert: l selectionModel selectedIndexes equals: #(  )
 ]
 
@@ -932,15 +879,14 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterInsert [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
 	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selecter currentIndex equals: 3.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1  ].
 	self assert: l selecter currentIndex equals: 3.
-	self waitTestingSpaces.
 	self assert: l selectionModel lastIndex equals: 4
 ]
 
@@ -949,18 +895,18 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterInsert1 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [
+		space root addChild: l.
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l dataAccessor size equals: 5.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }.
 	self assert: l selecter currentIndex equals: 3.
-	l forceLayout.
 	self assert: l nodeContainers size equals: 5.
-	l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10).
+
+	space deferAndSettle: [ l dataAccessor addAllFirst: (self statesOfAmerica copyFrom: 6 to: 10) ].
 	self assert: l dataAccessor size equals: 10.
-	self waitTestingSpaces.
 	self assert: l nodeContainers size equals: 10.
 	self assert: l selectionModel lastIndex equals: 8
 ]
@@ -970,19 +916,18 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterInsert3 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
+	space deferAndSettle: [ space root addChild: l ].
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
+	space deferAndSettle: [ l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
 	self assert: l selectionModel isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
 	self assert: l selecter currentIndex equals: 4.
-	l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1.
+
+	space deferAndSettle: [ l dataAccessor add: (self statesOfAmerica at: 6) afterIndex: 1 ].
 	self assert: l selecter currentIndex equals: 4.
 	self assert: l selecter currentIndex equals: 4.
-	self waitTestingSpaces.
 	self assert: l selectionModel selectedIndexes equals: #( 4 5 )
 ]
 
@@ -991,14 +936,11 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) .
 	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
-	l dataAccessor removeAt: 2.
-
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: { 2 }
 ]
 
@@ -1007,17 +949,19 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove1 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
-	l fitContent.
-	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	l forceLayout.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
-	self assert: l selectionModel selectedIndexes equals: { 3 }.
-	l dataAccessor removeAll.
-	self waitTestingSpaces.
-	self assert: l dataAccessor size equals: 0.
-	self assert: l selectionModel isEmpty
+	space deferAndSettle: [
+		space root addChild: l.
+		l fitContent ].
+	space deferAndSettle: [
+		l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5) ].
+	"Must be in a separate block to let layout process item addition before selection"
+	space deferAndSettle: [
+		l selecter selectOnlyIndex: 3 ].
+	self assert: (l selectionModel selectedIndexes) equals: { 3 }.
+
+	space deferAndSettle: [ l dataAccessor removeAll ].
+	self assert: (l dataAccessor size) equals: 0.
+	self assert: (l selectionModel isEmpty)
 ]
 
 { #category : #'test selection - adding/removing' }
@@ -1025,16 +969,15 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove2 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor size equals: 5.
-	self waitTestingSpaces.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOnlyIndex: 3.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOnlyIndex: 3 ].
 	self assert: l selecter currentIndex equals: 3.
-	l dataAccessor removeAt: 4.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [ l dataAccessor removeAt: 4 ].
 	self assert: l selectionModel selectedIndexes equals: { 3 }
 ]
 
@@ -1043,16 +986,15 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove3 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 2.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 3 )
 ]
 
@@ -1061,18 +1003,16 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove4 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l dataAccessor size equals: 5.
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 2 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 2 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 2 ).
-	l dataAccessor removeAt: 2.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+	
+	space deferAndSettle: [ l dataAccessor removeAt: 2 ].
 	self assert: l selectionModel selectedIndexes isEmpty
 ]
 
@@ -1081,16 +1021,15 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove5 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor removeAt: 3 ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 )
 ]
 
@@ -1099,17 +1038,17 @@ ToListElementWithFiniteInnerElementTest >> testSelectionUpdatedAfterRemove6 [
 
 	| l |
 	l := ToListElement finite.
-	space root addChild: l.
 	l fitContent.
 	l dataAccessor addAll: (self statesOfAmerica copyFrom: 1 to: 5).
+	space deferAndSettle: [ space root addChild: l ].
 	self assert: l selectionModel selectedIndexes isEmpty.
-	l selecter selectIndexes: #( 3 4 ).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectIndexes: #( 3 4 ) ].
 	self assert: l selectionModel selectedIndexes equals: #( 3 4 ).
-	l dataAccessor removeAt: 3.
-	l dataAccessor removeAt: 3.
-	self waitTestingSpaces.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l dataAccessor removeAt: 3.
+		l dataAccessor removeAt: 3 ].
 	self assert: l selectionModel selectedIndexes equals: #(  )
 ]
 
@@ -1119,14 +1058,13 @@ ToListElementWithFiniteInnerElementTest >> testSelectionWithOneNode [
 	| l |
 	l := ToListElement finite.
 	l dataAccessor removeAll.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
 	self assert: l selectionModel selectedIndexes equals: { 1 }
 ]
@@ -1136,16 +1074,16 @@ ToListElementWithFiniteInnerElementTest >> testSelectionWithTwoNodes [
 
 	| l |
 	l := ToListElement finite.
-	l dataAccessor add: 'first'.
-	space root addChild: l.
-	l innerElement forceLayout.	self waitTestingSpaces.
+	space deferAndSettle: [
+		l dataAccessor add: 'first'.
+		space root addChild: l ].
 	self assert: l innerElement children size equals: 1.
 	self assert: l selectionModel isEmpty.
-	l selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l selecter selectOneMoreIndex: 1 ].
 	self assert: l selecter selectedIndex equals: 1.
-	l dataAccessor addFirst: 'second'.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ l dataAccessor addFirst: 'second' ].
 	self assert: l selecter selectedIndex equals: 2.
 	self assert: l selecter selectedIndexes equals: { 2 }
 ]

--- a/src/Toplo-Widget-List-Tests/ToMultiSelectionModelSelecterTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToMultiSelectionModelSelecterTest.class.st
@@ -30,27 +30,27 @@ ToMultiSelectionModelSelecterTest >> setUp [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testDeselectAll [
 
-	selecter selectIndexes: {2. 6. 9}.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndexes: {2. 6. 9}.
+		selecter deselectAll ].
 	self assert: element selectionModel isEmpty
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testDeselectIndex [
 
-	selecter selectIndex: 2.
-	selecter deselectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter deselectIndex: 2 ].
 	self assert: element selectionModel isEmpty
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testDeselectIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	selecter deselectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndexes: {2. 6. 9}.
+		selecter deselectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel isEmpty 
 ]
 
@@ -62,23 +62,21 @@ ToMultiSelectionModelSelecterTest >> testDispatchSelectionChanged [
 			 on: ToListPrimarySelectionChangedEvent
 			 do: [ :event | selChangedEvent := event ]).
 
-	selecter selectionModel deselectAll.
-	selecter selectIndexes: { 2. 6. 9 }.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectionModel deselectAll.
+		selecter selectIndexes: { 2. 6. 9 } ].
 	self assert: selChangedEvent notNil.
 
 	selChangedEvent := nil.
 	" no change "
-	selecter selectIndexes: { 2. 6. 9 }.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: { 2. 6. 9 } ].
 	self assert: selChangedEvent isNil
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAll [
 
-	selecter selectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectAll ].
 	self assert: element selectionModel isNotEmpty.
 	self assert: selecter currentIndex equals: element selectionModel itemCount
 ]
@@ -86,10 +84,10 @@ ToMultiSelectionModelSelecterTest >> testSelectAll [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 
-	selecter selectIndex: 2.
-	selecter selectIndex: 10.
-	selecter scrollToDataSourcePosition: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter selectIndex: 10.
+		selecter scrollToDataSourcePosition: 10 ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: #( 2 10 ) asSet.
@@ -100,12 +98,9 @@ ToMultiSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAndScrollToNext [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter nextSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [ selecter selectIndex: selecter nextSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: #( 2 3 ) asSet.
@@ -116,18 +111,17 @@ ToMultiSelectionModelSelecterTest >> testSelectAndScrollToNext [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter nextDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 2 3 ).
 	self assert: selecter currentIndex equals: 3.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter nextDeselectedIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 2 3 4 ).
 	self assert: selecter currentIndex equals: 4.
 	self assert: element scrollIndex equals: 4
@@ -136,12 +130,9 @@ ToMultiSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAndScrollToPrevious [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [ selecter selectIndex: selecter previousSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: #( 1 2 ) asSet.
@@ -152,17 +143,18 @@ ToMultiSelectionModelSelecterTest >> testSelectAndScrollToPrevious [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 1 2 ).
 	self assert: selecter currentIndex equals: 1.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 1 2 ).
 	self assert: selecter currentIndex equals: 1.
 	self assert: element scrollIndex equals: 1
@@ -171,8 +163,7 @@ ToMultiSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes size equals: 1.
 	self assert: element selectionModel selectedIndexes first equals: 2
 ]
@@ -180,8 +171,7 @@ ToMultiSelectionModelSelecterTest >> testSelectIndex [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectIndex2 [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: selecter currentIndex equals: 2
 ]
@@ -189,8 +179,7 @@ ToMultiSelectionModelSelecterTest >> testSelectIndex2 [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectIndexTo [
 
-	selecter selectIndex: 2 to: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 to: 10 ].
 	self assert: element selectionModel selectedIndexes size equals: 9.
 	self assert: element selectionModel selectedIndexes asSet equals: (2 to: 10) asSet
 ]
@@ -198,16 +187,14 @@ ToMultiSelectionModelSelecterTest >> testSelectIndexTo [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectIndexTo2 [
 
-	selecter selectIndex: 2 to: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 to: 10 ].
 	self assert: selecter currentIndex equals: 10
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel selectedIndexes size equals: 3.
 	self assert: element selectionModel selectedIndexes equals: {2. 6. 9} 
 ]
@@ -215,15 +202,13 @@ ToMultiSelectionModelSelecterTest >> testSelectIndexes [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 
-	selecter selectIndex: element itemCount.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: element itemCount ].
 	self
 		assert: selecter currentIndex
 		equals: element  itemCount.
-	selecter selectIndex: selecter nextSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter nextSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: { 100. 1 } asSet.
@@ -234,32 +219,30 @@ ToMultiSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectOnlyIndex [
 
-	selecter deselectAll.
-	selecter selectIndexes: {2. 6. 9}.
-	selecter selectOnlyIndex: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndexes: {2. 6. 9}.
+		selecter selectOnlyIndex: 10 ].
 	self assert: element selectionModel selectedIndexes asSet equals: {10} asSet.
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectOnlyIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	selecter selectOnlyIndexes: {10. 6. 20}.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndexes: {2. 6. 9}.
+		selecter selectOnlyIndexes: {10. 6. 20} ].
 	self assert: element selectionModel selectedIndexes equals: {6. 10. 20}.
 ]
 
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 
-	selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 1 ].
 	self assert: selecter currentIndex equals: 1.
-	selecter selectIndex: selecter previousSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter previousSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: {
 			1.
 			element  itemCount }.
@@ -272,9 +255,9 @@ ToMultiSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectThenDeselectAll [
 
-	selecter selectIndex: 2.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter deselectAll ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0
 ]
@@ -282,21 +265,19 @@ ToMultiSelectionModelSelecterTest >> testSelectThenDeselectAll [
 { #category : #tests }
 ToMultiSelectionModelSelecterTest >> testSelectToIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: selecter currentIndex equals: 2.
-	selecter selectIndex: 2 to: 12.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: 2 to: 12 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: element selectionModel selectedIndexes last equals: 12.
 	self assert: selecter currentIndex equals: 12.
-	selecter selectIndex: 12 to: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: 12 to: 2 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: element selectionModel selectedIndexes last equals: 12.
 	self assert: selecter currentIndex equals: 2
-
 ]
 
 { #category : #tests }
@@ -304,10 +285,8 @@ ToMultiSelectionModelSelecterTest >> testSelectionChanged [
 
 	selectionChanged := false.
 	element addEventHandlerOn: ToListPrimarySelectionChangedEvent  do: [ selectionChanged := true ].
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
 	self assert: selectionChanged. 
-
 ]
 
 { #category : #tests }
@@ -315,10 +294,8 @@ ToMultiSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll [
 
 	selectionChanged := false.
 	element addEventHandlerOn: ToListPrimarySelectionChangedEvent  do: [ selectionChanged := true ].
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
+	space deferAndSettle: [ selecter deselectAll ].
 	self assert: selectionChanged
 ]
 
@@ -327,10 +304,9 @@ ToMultiSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll2 [
 
 	selectionChanged := false.
 	element addEventHandlerOn: ToListPrimarySelectionChangedEvent  do: [ selectionChanged := true ].
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
-	selecter deselectAll.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter deselectAll ].
 	self assert: selectionChanged
 ]

--- a/src/Toplo-Widget-List-Tests/ToNoneSelectionModelSelecterTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToNoneSelectionModelSelecterTest.class.st
@@ -29,31 +29,29 @@ ToNoneSelectionModelSelecterTest >> setUp [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testDeselectAll [
 
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel selectedIndexes isEmpty.
-	selecter deselectAll.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter deselectAll ].
 	self assert: element selectionModel isEmpty
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testDeselectIndex [
 
-	selecter selectIndex: 2.
-	selecter deselectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter deselectIndex: 2 ].
 	self assert: element selectionModel isEmpty
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testDeselectIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel selectedIndexes isEmpty.
-	selecter deselectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter deselectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel isEmpty 
 ]
 
@@ -65,34 +63,28 @@ ToNoneSelectionModelSelecterTest >> testDispatchSelectionChanged [
 			 on: ToListPrimarySelectionChangedEvent
 			 do: [ :event | selChangedEvent := event ]).
 
-	selecter selectIndexes: { 2. 6. 9 }.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: { 2. 6. 9 } ].
 	self assert: selChangedEvent isNil.
-	self waitTestingSpaces.
 	self assert: element selectionModel selectedIndexes isEmpty.
 
 	selChangedEvent := nil.
 	" no change "
-	selecter selectIndexes: { 2. 6. 9 }.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: { 2. 6. 9 } ].
 	self assert: element selectionModel selectedIndexes isEmpty.
-	self waitTestingSpaces.
 	self assert: selChangedEvent isNil
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAll [
 
-	selecter selectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectAll ].
 	self assert: element selectionModel isEmpty
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAll2 [
 
-	selecter selectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectAll ].
 	self assert: selecter currentIndex equals: 0.
 	self assert: element selectionModel isEmpty
 ]
@@ -100,11 +92,10 @@ ToNoneSelectionModelSelecterTest >> testSelectAll2 [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: 10.
-	selecter scrollToDataSourcePosition: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: 10.
+		selecter scrollToDataSourcePosition: 10 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -113,11 +104,10 @@ ToNoneSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAndScrollToNext [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter nextSelectableIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter nextSelectableIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -126,17 +116,18 @@ ToNoneSelectionModelSelecterTest >> testSelectAndScrollToNext [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter nextDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter nextDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -145,11 +136,10 @@ ToNoneSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAndScrollToPrevious [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousSelectableIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousSelectableIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -158,17 +148,18 @@ ToNoneSelectionModelSelecterTest >> testSelectAndScrollToPrevious [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -177,16 +168,14 @@ ToNoneSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes isEmpty
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectIndex2 [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0
 ]
@@ -194,36 +183,33 @@ ToNoneSelectionModelSelecterTest >> testSelectIndex2 [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectIndexTo [
 
-	selecter selectIndex: 2 to: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 to: 10 ].
 	self assert: element selectionModel selectedIndexes isEmpty
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectIndexTo2 [
 
-	selecter selectIndex: 2 to: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 to: 10 ].
 	self assert: selecter currentIndex equals: 0
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2. 6. 9} ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 
-	selecter selectIndex: element itemCount.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: element itemCount ].
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: selecter nextSelectableIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter nextSelectableIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -232,31 +218,31 @@ ToNoneSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectOnlyIndex [
 
-	selecter deselectAll.
-	selecter selectIndexes: {2. 6. 9}.
-	selecter selectOnlyIndex: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndexes: {2. 6. 9}.
+		selecter selectOnlyIndex: 10 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectOnlyIndexes [
 
-	selecter selectIndexes: {2. 6. 9}.
-	selecter selectOnlyIndexes: {10. 6. 20}.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndexes: {2. 6. 9}.
+		selecter selectOnlyIndexes: {10. 6. 20} ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 
-	selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 1 ].
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: selecter previousSelectableIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousSelectableIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
 	self assert: element scrollIndex equals: nil
@@ -265,9 +251,9 @@ ToNoneSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectThenDeselectAll [
 
-	selecter selectIndex: 2.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter deselectAll ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0
 ]
@@ -275,38 +261,32 @@ ToNoneSelectionModelSelecterTest >> testSelectThenDeselectAll [
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectToIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: 2 to: 12.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: 2 to: 12 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0.
-	selecter selectIndex: 12 to: 2.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: 12 to: 2 ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0
-
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectionChanged [
 
-	selecter selectIndexes: {2}.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2} ].
 	self deny: selectionChanged. 
-
 ]
 
 { #category : #tests }
 ToNoneSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll [
 
 	selectionChanged := false.
-	selecter selectIndexes: {2}.
-	self waitTestingSpaces.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2} ].
+	space deferAndSettle: [ selecter deselectAll ].
 	self deny: selectionChanged
 ]
 
@@ -314,10 +294,9 @@ ToNoneSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll [
 ToNoneSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll2 [
 
 	selectionChanged := false.
-	selecter selectIndexes: {2 }.
-	self waitTestingSpaces.
-	selecter deselectAll.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndexes: {2 } ].
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter deselectAll ].
 	self deny: selectionChanged
 ]

--- a/src/Toplo-Widget-List-Tests/ToPrimarySelecterTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToPrimarySelecterTest.class.st
@@ -34,10 +34,11 @@ ToPrimarySelecterTest >> testAddCommand [
 			 do: [ :event | selChangedEvent := event ]).
 	element selectionModel deselectAll.
 	self assert: element selectionModel isEmpty.
-	selecter addCommand: (cmd := ToWholeSelectionCommand new
-			        operation: ToAddSelectionOperation new;
-			        yourself).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter addCommand: (cmd := ToWholeSelectionCommand new
+				        operation: ToAddSelectionOperation new;
+				        yourself) ].
 	self assert: element selectionModel isNotEmpty.
 	self assert: selChangedEvent notNil
 ]
@@ -48,12 +49,13 @@ ToPrimarySelecterTest >> testDeselectTo [
 	| cmd |
 	element selectionModel selectOneMoreIndex: element itemCount + 1.
 	self assert: element selectionModel selectedIndexes equals: #( 101 ).
-	selecter addCommand: (cmd := ToIntervalSelectionCommand new
-			        from: 1;
-			        to: element itemCount + 1;
-			        operation: ToRemoveSelectionOperation new;
-			        yourself).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter addCommand: (cmd := ToIntervalSelectionCommand new
+				        from: 1;
+				        to: element itemCount + 1;
+				        operation: ToRemoveSelectionOperation new;
+				        yourself) ].
 	self assert: element selectionModel isEmpty
 ]
 
@@ -67,11 +69,12 @@ ToPrimarySelecterTest >> testDeselectToWithChangedItemCount [
 	self assert: element selectionModel selectedIndexes equals: { to }.
 	element selectionModel itemCountGetter: 0.
 	self assert: element selectionModel itemCount equals: 0.
-	selecter addCommand: (cmd := ToIntervalSelectionCommand new
-			        from: 1;
-			        to: to;
-			        operation: ToRemoveSelectionOperation new;
-			        yourself).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter addCommand: (cmd := ToIntervalSelectionCommand new
+				        from: 1;
+				        to: to;
+				        operation: ToRemoveSelectionOperation new;
+				        yourself) ].
 	self assert: element selectionModel isEmpty
 ]

--- a/src/Toplo-Widget-List-Tests/ToSingleSelectionModelSelecterTest.class.st
+++ b/src/Toplo-Widget-List-Tests/ToSingleSelectionModelSelecterTest.class.st
@@ -30,11 +30,10 @@ ToSingleSelectionModelSelecterTest >> setUp [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testDeselectAll [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes equals: { 2 }.
-	selecter deselectAll.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter deselectAll ].
 	self assert: element selectionModel isEmpty
 ]
 
@@ -48,14 +47,13 @@ ToSingleSelectionModelSelecterTest >> testDeselectIndex [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testDeselectIndexes [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes equals: #( 2 ).
-	selecter deselectIndexes: {3. 6. 9}.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter deselectIndexes: {3. 6. 9} ].
 	self assert: element selectionModel selectedIndexes equals: #( 2 ).
-	selecter deselectIndexes: {3. 2. 9}.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter deselectIndexes: {3. 2. 9} ].
 	self assert: element selectionModel selectedIndexes equals: #(  ).
 
 
@@ -71,18 +69,14 @@ ToSingleSelectionModelSelecterTest >> testDispatchSelectionChanged [
 			 on: ToListPrimarySelectionChangedEvent
 			 do: [ :event | selChangedEvent := event ]).
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: selChangedEvent notNil.
-	self waitTestingSpaces.
 	self assert: element selectionModel selectedIndexes equals: { 2 }.
 
 	selChangedEvent := nil.
 	" no change "
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes equals: { 2 }.
-	self waitTestingSpaces.
 	self assert: selChangedEvent isNil
 ]
 
@@ -96,12 +90,9 @@ ToSingleSelectionModelSelecterTest >> testSelectAll [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: 10.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [ selecter selectIndex: 10 ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 10 ).
 	self assert: selecter currentIndex equals: 10.
 	self assert: element scrollIndex equals: 10
@@ -110,16 +101,13 @@ ToSingleSelectionModelSelecterTest >> testSelectAndScrollToIndex [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectAndScrollToNext [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: selecter currentIndex equals: 2.
 
-	selecter selectIndex: selecter nextSelectableIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: selecter nextSelectableIndex ].
 	self assert: selecter currentIndex equals: 3.
 
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: #( 3 ) asSet.
@@ -130,19 +118,16 @@ ToSingleSelectionModelSelecterTest >> testSelectAndScrollToNext [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [ selecter selectIndex: selecter nextDeselectedIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 3 ).
 	self assert: selecter currentIndex equals: 3.
-	selecter selectIndex: selecter nextDeselectedIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter nextDeselectedIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 4 ).
 	self assert: selecter currentIndex equals: 4.
 	self assert: element scrollIndex equals: 4
@@ -151,34 +136,31 @@ ToSingleSelectionModelSelecterTest >> testSelectAndScrollToNextDeselected [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectAndScrollToPrevious [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
+	space deferAndSettle: [ selecter selectIndex: selecter previousSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: #( 1 ) asSet.
 	self assert: selecter currentIndex equals: 1.
-	self waitTestingSpaces.
 	self assert: element scrollIndex equals: 1
 ]
 
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2 ].
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 1 ).
 	self assert: selecter currentIndex equals: 1.
-	selecter selectIndex: selecter previousDeselectedIndex.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		selecter selectIndex: selecter previousDeselectedIndex.
+		selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self assert: element selectionModel selectedIndexes equals: #( 1 ).
 	self assert: selecter currentIndex equals: 1.
 	self assert: element scrollIndex equals: 1
@@ -187,8 +169,7 @@ ToSingleSelectionModelSelecterTest >> testSelectAndScrollToPreviousDeselected [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes size equals: 1.
 	self assert: element selectionModel selectedIndexes first equals: 2
 ]
@@ -196,8 +177,7 @@ ToSingleSelectionModelSelecterTest >> testSelectIndex [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectIndex2 [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: selecter currentIndex equals: 2
 ]
@@ -207,8 +187,7 @@ ToSingleSelectionModelSelecterTest >> testSelectIndexTo [
 
 	self should: [selecter selectIndex: 2 to: 4] raise: Error.
 	self should: [selecter selectIndex: 4 to: 2] raise: Error.
-	selecter selectIndex: 2 to: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 to: 2 ].
 	self assert: element selectionModel selectedIndexes  equals: {2} .
 ]
 
@@ -222,15 +201,13 @@ ToSingleSelectionModelSelecterTest >> testSelectIndexes [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 
-	selecter selectIndex: element itemCount.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: element itemCount ].
 	self
 		assert: selecter currentIndex
 		equals: element itemCount.
-	selecter selectIndex: selecter nextSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter nextSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: { 1 } asSet.
@@ -241,10 +218,10 @@ ToSingleSelectionModelSelecterTest >> testSelectNextOnLastIndex [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectOnlyIndex [
 
-	selecter deselectAll.
-	selecter selectIndex: 2.
-	selecter selectOnlyIndex: 10.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter deselectAll.
+		selecter selectIndex: 2.
+		selecter selectOnlyIndex: 10 ].
 	self assert: element selectionModel selectedIndexes asSet equals: {10} asSet.
 ]
 
@@ -257,13 +234,11 @@ ToSingleSelectionModelSelecterTest >> testSelectOnlyIndexes [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 
-	selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 1 ].
 	self assert: selecter currentIndex equals: 1.
-	selecter selectIndex: selecter previousSelectableIndex.
-	self waitTestingSpaces.
-	selecter scrollToDataSourcePosition: selecter currentIndex.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ selecter selectIndex: selecter previousSelectableIndex ].
+	space deferAndSettle: [ selecter scrollToDataSourcePosition: selecter currentIndex ].
 	self
 		assert: element selectionModel selectedIndexes asSet
 		equals: { element itemCount } asSet.
@@ -276,9 +251,9 @@ ToSingleSelectionModelSelecterTest >> testSelectPreviousOnFirstIndex [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectThenDeselectAll [
 
-	selecter selectIndex: 2.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		selecter selectIndex: 2.
+		selecter deselectAll ].
 	self assert: element selectionModel selectedIndexes isEmpty.
 	self assert: selecter currentIndex equals: 0
 ]
@@ -286,8 +261,7 @@ ToSingleSelectionModelSelecterTest >> testSelectThenDeselectAll [
 { #category : #tests }
 ToSingleSelectionModelSelecterTest >> testSelectToIndex [
 
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: element selectionModel selectedIndexes first equals: 2.
 	self assert: selecter currentIndex equals: 2.
 	self should: [selecter selectIndex: 2 to: 12 ] raise: Error
@@ -298,11 +272,9 @@ ToSingleSelectionModelSelecterTest >> testSelectionChanged [
 
 	selectionChanged := false.
 	element addEventHandlerOn: ToListPrimarySelectionChangedEvent  do: [ selectionChanged := true ].
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	
 	self assert: selectionChanged. 
-
 ]
 
 { #category : #tests }
@@ -312,15 +284,12 @@ ToSingleSelectionModelSelecterTest >> testSelectionChangedOnDeselectAll [
 	element
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ selectionChanged := true ].
-	selecter selectIndex: 2.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter selectIndex: 2 ].
 	self assert: selectionChanged.
 	selectionChanged := false.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter deselectAll ].
 	self assert: selectionChanged.
 	selectionChanged := false.
-	selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ selecter deselectAll ].
 	self deny: selectionChanged
 ]

--- a/src/Toplo-Widget-List/ToListPrimarySelectionElementEventHandler.class.st
+++ b/src/Toplo-Widget-List/ToListPrimarySelectionElementEventHandler.class.st
@@ -39,7 +39,7 @@ ToListPrimarySelectionElementEventHandler >> listCheckableNodeUseChanged: anEven
 				listElement selectionMode selectOnClick: false ]
 		ifFalse: [
 		listElement selectionMode selectOnClick: wasSelectingOnClick ].
-	listElement inUIProcessDo: [ listElement notifyDataSourceChanged ]
+	listElement deferOrValue: [ listElement notifyDataSourceChanged ]
 ]
 
 { #category : #'element handlers' }

--- a/src/Toplo-Widget-Menu-Tests/ToMenuItemFiniteListElementTest.class.st
+++ b/src/Toplo-Widget-Menu-Tests/ToMenuItemFiniteListElementTest.class.st
@@ -16,7 +16,8 @@ ToMenuItemFiniteListElementTest >> setUp [
 	super setUp.
 	l := ToMenuItemListElement new.
 	l vMatchParent.
-	space root addChild: l
+	space deferAndSettle: [
+		space root addChild: l ]
 ]
 
 { #category : #tests }
@@ -25,15 +26,15 @@ ToMenuItemFiniteListElementTest >> test [
 	| n |
 	self assert: l nodeContainers size equals: l dataAccessor size.
 	self assert: (l nodeManager isKindOf: ToItemListNodeManager).
-	l addAllItems:
-		((1 to: 10) collect: [ :i | ToMenuItem new labelText: i asString ]).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		l addAllItems:
+			((1 to: 10) collect: [ :i | ToMenuItem new labelText: i asString ]) ].
 	self assert: l nodeContainers size equals: 10.
 	n := l nodeContainers first.
 	self assert: (n node isKindOf: ToMenuItemNode).
 	self assert: (n holder isKindOf: ToItemNodeHolder).
 	self assert: (n holder dataItem isKindOf: ToMenuItem)
-	
 ]
 
 { #category : #tests }
@@ -41,8 +42,7 @@ ToMenuItemFiniteListElementTest >> testAddItem [
 
 	| n item |
 	item := ToMenuItem new labelText: '#1'.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l addItem: item ].
 	self assert: l nodeContainers size equals: 1.
 	n := l nodeContainers first node.
 	self assert: (n isKindOf: ToMenuItemNode).
@@ -58,9 +58,9 @@ ToMenuItemFiniteListElementTest >> testDisableItemAfterAdding [
 	| n item |
 	self assert: l nodeContainers size equals: 0.
 	item := ToMenuItem new labelText: 'A'.
-	l addItem: item.
-	item disable.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		l addItem: item.
+		item disable ].
 	self assert: l nodeContainers size equals: 1.
 	n := l nodeContainers first node.
 	self assert: n holder dataItem identicalTo: item.
@@ -77,13 +77,13 @@ ToMenuItemFiniteListElementTest >> testDisableItemAfterAdding2 [
 	| n item |
 	self assert: l nodes size equals: 0.
 	item := ToMenuItem new labelText: 'A'.
-	l addItem: item.
+	space deferAndSettle: [ l addItem: item ].
 	item := ToMenuItem new labelText: 'B'.
-	l addItem: item.
-	item disable.
+	space deferAndSettle: [
+		l addItem: item.
+		item disable ].
 	item := ToMenuItem new labelText: 'C'.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l addItem: item ].
 
 	n := l nodes first.
 	self assert: n item positionInList equals: 1.
@@ -93,7 +93,6 @@ ToMenuItemFiniteListElementTest >> testDisableItemAfterAdding2 [
 	self deny: n isDisabled.
 
 	n := l nodes second.
-	self waitTestingSpaces.
 	self assert: n item positionInList equals: 2.
 	self assert:
 		(l disabledSelectionModel containsIndex: n item positionInList).
@@ -115,8 +114,7 @@ ToMenuItemFiniteListElementTest >> testDisableItemBeforeAdding [
 	self assert: l nodes size equals: 0.
 	item := ToMenuItem new labelText: 'A'.
 	item disabled: true.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l addItem: item ].
 
 	n := l nodes first.
 	self assert: n holder dataItem identicalTo: item.
@@ -134,13 +132,13 @@ ToMenuItemFiniteListElementTest >> testDisableItemBeforeAdding2 [
 	| n item |
 	self assert: l nodes size equals: 0.
 	item := ToMenuItem new labelText: 'A'.
-	l addItem: item.
+	space deferAndSettle: [ l addItem: item ].
 	item := ToMenuItem new labelText: 'B'.
-	item disable.
-	l addItem: item.
+	space deferAndSettle: [
+		item disable.
+		l addItem: item ].
 	item := ToMenuItem new labelText: 'C'.
-	l addItem: item.
-	self waitTestingSpaces.
+	space deferAndSettle: [ l addItem: item ].
 
 	n := l nodes first.
 	self assert: n item positionInList equals: 1.
@@ -150,7 +148,6 @@ ToMenuItemFiniteListElementTest >> testDisableItemBeforeAdding2 [
 	self deny: n isDisabled.
 
 	n := l nodes second.
-	self waitTestingSpaces.
 	self assert: n item positionInList equals: 2.
 	self assert:
 		(l disabledSelectionModel containsIndex: n item positionInList).

--- a/src/Toplo-Widget-Menu-Tests/ToMenuTest.class.st
+++ b/src/Toplo-Widget-Menu-Tests/ToMenuTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToMenuTest is a test class for testing the behavior of ToMenu
-"
 Class {
 	#name : #ToMenuTest,
 	#superclass : #ToParameterizedHostTest,
@@ -15,7 +12,7 @@ ToMenuTest >> setUp [
 
 	super setUp. 
 	m := ToMenu new labelText: 'Menu'.
-	space root addChild: m
+	space deferAndSettle: [ space root addChild: m ]
 ]
 
 { #category : #tests }
@@ -23,9 +20,9 @@ ToMenuTest >> testAddItem [
 
 	| n item |
 	item := ToMenuItem new labelText: 'Menu'.
-	m addItem: item.
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		m addItem: item.
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
 	n := m manager currentWindow itemList nodes first.
 	self assert: (n isKindOf: ToMenuItemNode).
@@ -39,12 +36,12 @@ ToMenuTest >> testAddItem [
 ToMenuTest >> testBuilderDisableItemAfterAdding [
 
 	| n item |
-	m builder: [ :theMenu :theRequest |
-		item := ToMenuItem new labelText: 'Item #1'.
-		theMenu addItem: item.
-		item disable ].
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		m builder: [ :theMenu :theRequest |
+			item := ToMenuItem new labelText: 'Item #1'.
+			theMenu addItem: item.
+			item disable ].
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
 	n := m menuWindow itemList nodes first.
 	self assert:
@@ -58,12 +55,12 @@ ToMenuTest >> testBuilderDisableItemAfterAdding [
 ToMenuTest >> testBuilderDisableItemBeforeAdding [
 
 	| n item |
-	m builder: [ :theMenu :theRequest |
-		item := ToMenuItem new labelText: 'Item #1'.
-		item disable.
-		theMenu addItem: item ].
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		m builder: [ :theMenu :theRequest |
+			item := ToMenuItem new labelText: 'Item #1'.
+			item disable.
+			theMenu addItem: item ].
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
 	n := m menuWindow itemList nodes first.
 	self assert:
@@ -80,13 +77,15 @@ ToMenuTest >> testCheckableItem [
 	item := ToRadioMenuItem new
 			 label: (ToLabel text: 'Dark theme');
 			 yourself.
-	m addItem: item.
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		m addItem: item.
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
-	item checked: true.
+
+	space deferAndSettle: [ item checked: true ].
 	self assert: item isChecked.
-	item checked: false.
+
+	space deferAndSettle: [ item checked: false ].
 	self deny: item isChecked
 ]
 
@@ -95,10 +94,10 @@ ToMenuTest >> testDisableItemAfterAdding [
 
 	| n item |
 	item := ToMenuItem new labelText: 'Item #1'.
-	m addItem: item.
-	item disable.
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		m addItem: item.
+		item disable.
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
 	n := m menuWindow itemList nodes first.
 	self assert:
@@ -113,10 +112,10 @@ ToMenuTest >> testDisableItemBeforeAdding [
 
 	| n item |
 	item := ToMenuItem new labelText: 'Menu'.
-	item disable.
-	m addItem: item.
-	m popupEvent: nil.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		item disable.
+		m addItem: item.
+		m popupEvent: nil ].
 	self assert: m menuWindow itemList nodes size equals: 1.
 	n := m menuWindow itemList nodes first.
 	self assert:

--- a/src/Toplo-Widget-Select-Tests/ToMultiSelectElementTest.class.st
+++ b/src/Toplo-Widget-Select-Tests/ToMultiSelectElementTest.class.st
@@ -15,11 +15,13 @@ ToMultiSelectElementTest >> testAddDataAndSelectIndex [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb selecter selectOneMoreIndex: 1.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb popupDataAccessor size equals: 3.
 	self assert: cb selecter selectedIndex equals: 1.
 	self
@@ -33,10 +35,12 @@ ToMultiSelectElementTest >> testAddRemoveOneStringData [
 	| cb d |
 	cb := ToMultiSelectElement new.
 	d := '#1'.
-
-	cb popupDataAccessor add: d.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor add: d ].
 	self assert: cb popupDataAccessor size equals: 1.
-	cb popupDataAccessor remove: d.
+
+	space deferAndSettle: [ cb popupDataAccessor remove: d ].
 	self assert: cb popupDataAccessor isEmpty
 ]
 
@@ -46,7 +50,9 @@ ToMultiSelectElementTest >> testNoSelectedData [
 	| cb d |
 	cb := ToMultiSelectElement new.
 	d := { '#1'. '#2'. '#3'. '#4'. '#5' }.
-	cb popupDataAccessor addAll: d.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: d ].
 	self assert: cb selecter selectedIndex isZero.
 	self assert: cb selecter selectedIndexes isEmpty
 
@@ -57,10 +63,10 @@ ToMultiSelectElementTest >> testNoSelectedData2 [
 
 	| cb |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
+	space deferAndSettle: [ space root addChild: cb ].
 	self assert: cb selecter selectedIndex isZero.
-	cb selecter selectOneMoreIndex: 0.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb selecter selectOneMoreIndex: 0 ].
 	self assert: cb selecter selectedIndex isZero
 ]
 
@@ -69,23 +75,21 @@ ToMultiSelectElementTest >> testRemove [
 
 	| cb d1 d2 d3 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
-	cb popupDataAccessor removeFirst.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFirst ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -95,22 +99,21 @@ ToMultiSelectElementTest >> testRemove1 [
 
 	| cb d1 d2 d3 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
-	cb popupDataAccessor removeAt: 1.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeAt: 1 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -120,22 +123,21 @@ ToMultiSelectElementTest >> testRemove2 [
 
 	| cb d1 d2 d3 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
-	cb popupDataAccessor removeFrom: 1 to: 1.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 1 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -145,22 +147,21 @@ ToMultiSelectElementTest >> testRemove3 [
 
 	| cb d1 d2 d3 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
-	cb popupDataAccessor removeFrom: 1 to: 2.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 2 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -173,15 +174,18 @@ ToMultiSelectElementTest >> testRemove4 [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb selecter selectIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
-	cb popupDataAccessor removeFrom: 1 to: 3.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 3 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -191,26 +195,23 @@ ToMultiSelectElementTest >> testRemove5 [
 
 	| cb d1 d2 d3 d4 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
 	d4 := '#4'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3.
 			d4 }.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+		cb manager popup.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement nodes size equals: 1.
 
-	cb popupDataAccessor removeFrom: 1 to: 3.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 3 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement nodes isEmpty
 ]
@@ -220,23 +221,22 @@ ToMultiSelectElementTest >> testRemoveAll [
 
 	| cb d1 d2 d3 |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
-	self waitTestingSpaces.
+		cb selecter selectIndex: 1 ].
+
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb header nodes size equals: 1.
 
-	cb popupDataAccessor removeAll.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [ cb popupDataAccessor removeAll ].
+
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb header nodes isEmpty
 ]
@@ -249,11 +249,14 @@ ToMultiSelectElementTest >> testSelectAll [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
-			d3 }.
-	cb selecter selectAll.
+			d3 } ].
+	space deferAndSettle: [
+		cb selecter selectAll ].
 	self assert: cb selecter selectedIndexes equals: #(1 2 3).
 	self assert: cb innerElement nodes size equals: 3
 ]
@@ -263,16 +266,17 @@ ToMultiSelectElementTest >> testWithStructuredData [
 
 	| cb d idx selectedData |
 	cb := ToMultiSelectElement new.
-	space root addChild: cb.
-	cb popupListElement nodeBuilder: [ :node :assoc :holder |
-		node label: (ToLabel text: assoc key) ].
-	cb nodeBuilder: [ :node :assoc |
-		node label: (ToLabel text: assoc key) ].
-	cb popupListElement dataAccessor addAll: (d := {
-			      ('Bee Theme' -> ToBeeTheme).
-			      ('Raw Theme' -> ToRawTheme) }).
-	cb selecter selectOneMoreIndex: 1.
-	self waitTestingSpaces.
+	d := {
+      ('Bee Theme' -> ToBeeTheme).
+      ('Raw Theme' -> ToRawTheme) }.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupListElement nodeBuilder: [ :node :assoc :holder |
+			node label: (ToLabel text: assoc key) ].
+		cb nodeBuilder: [ :node :assoc |
+			node label: (ToLabel text: assoc key) ].
+		cb popupListElement dataAccessor addAll: d.
+		cb selecter selectOneMoreIndex: 1 ].
 	self assert: cb selectionModel selectedIndexesCount equals: 1.
 	idx := cb selectionModel selectedIndexes first.
 	selectedData := cb popupListElement dataAccessor at: idx.
@@ -280,8 +284,8 @@ ToMultiSelectElementTest >> testWithStructuredData [
 	self
 		assert: cb innerElement nodes first label text asString
 		equals: d first key.
-	cb selecter deselectAll.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb selecter deselectAll ].
 	self assert: cb selectionModel selectedIndexes isEmpty.
 	self assert: cb innerElement nodes isEmpty
 ]

--- a/src/Toplo-Widget-Select-Tests/ToSingleSelectElementTest.class.st
+++ b/src/Toplo-Widget-Select-Tests/ToSingleSelectElementTest.class.st
@@ -15,11 +15,12 @@ ToSingleSelectElementTest >> testAddDataAndSelectIndex [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb selecter selectIndex: 1.
+		cb selecter selectIndex: 1 ].
 	self assert: cb popupDataAccessor size equals: 3.
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb dataView firstChild text asString equals: d1
@@ -31,10 +32,12 @@ ToSingleSelectElementTest >> testAddRemoveOneStringData [
 	| cb d |
 	cb := ToSingleSelectElement new.
 	d := '#1'.
-
-	cb popupDataAccessor add: d.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor add: d ].
 	self assert: cb popupDataAccessor size equals: 1.
-	cb popupDataAccessor remove: d.
+
+	space deferAndSettle: [ cb popupDataAccessor remove: d ].
 	self assert: cb popupDataAccessor isEmpty
 ]
 
@@ -44,7 +47,9 @@ ToSingleSelectElementTest >> testNoSelectedData [
 	| cb d |
 	cb := ToSingleSelectElement new.
 	d := { '#1'. '#2'. '#3'. '#4'. '#5' }.
-	cb popupDataAccessor addAll: d.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: d ].
 	self assert: cb selecter selectedIndex isZero.
 	self assert: cb selecter selectedIndexes isEmpty
 
@@ -55,10 +60,10 @@ ToSingleSelectElementTest >> testNoSelectedData2 [
 
 	| cb |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
+	space deferAndSettle: [ space root addChild: cb ].
 	self assert: cb selecter selectedIndex isZero.
-	cb selecter selectIndex: 0.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb selecter selectIndex: 0 ].
 	self assert: cb selecter selectedIndex isZero
 ]
 
@@ -67,23 +72,22 @@ ToSingleSelectElementTest >> testRemove [
 
 	| cb d1 d2 d3 |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
-	self waitTestingSpaces.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
-	cb popupDataAccessor removeFirst.
-	self waitTestingSpaces.
-	cb popupListElement forceLayout.
-	self assert: cb selecter selectedIndexes equals: {  }.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFirst ].
+	self assert: cb selecter selectedIndexes equals: #().
 	self assert: cb innerElement dataView children isEmpty
 ]
 
@@ -92,21 +96,22 @@ ToSingleSelectElementTest >> testRemove1 [
 
 	| cb d1 d2 d3 |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
-			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
+			d3 } ].
+	space deferAndSettle: [
+		cb selecter selectIndex: 1 ].
+	space deferAndSettle: [ cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
-	cb popupDataAccessor removeAt: 1.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeAt: 1 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement dataView children isEmpty
 ]
@@ -116,21 +121,21 @@ ToSingleSelectElementTest >> testRemove2 [
 
 	| cb d1 d2 d3 |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
-	cb popupDataAccessor removeFrom:1 to: 1.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 1 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement dataView children isEmpty
 ]
@@ -140,21 +145,21 @@ ToSingleSelectElementTest >> testRemove3 [
 
 	| cb d1 d2 d3 |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
-	cb popupDataAccessor removeFrom:1 to: 2.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 2 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement dataView children isEmpty
 ]
@@ -167,17 +172,18 @@ ToSingleSelectElementTest >> testRemove4 [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
 
-	cb popupDataAccessor removeFrom: 1 to: 3.
-	cb popupListElement forceLayout.
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 3 ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement dataView children isEmpty
 ]
@@ -185,29 +191,26 @@ ToSingleSelectElementTest >> testRemove4 [
 { #category : #tests }
 ToSingleSelectElementTest >> testRemove5 [
 
-	| cb d1 d2 d3 d4|
+	| cb d1 d2 d3 d4 |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
 	d4 := '#4'.
-	cb popupDataAccessor addAll: {
-			d1.
-			d2.
-			d3.
-			d4 }.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
-	cb selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
+				d1.
+				d2.
+				d3.
+				d4 }.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
 
-	cb popupDataAccessor removeFrom: 1 to: 3.
-	cb popupListElement forceLayout.
-	self waitTestingSpaces.
-	self assert: cb selecter selectedIndexes equals: {  }.
+	space deferAndSettle: [ cb popupDataAccessor removeFrom: 1 to: 3 ].
+	self assert: cb selecter selectedIndexes equals: #().
 	self assert: cb innerElement dataView children isEmpty
 ]
 
@@ -219,17 +222,18 @@ ToSingleSelectElementTest >> testRemoveAll [
 	d1 := '#1'.
 	d2 := '#2'.
 	d3 := '#3'.
-	cb popupDataAccessor addAll: {
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupDataAccessor addAll: {
 			d1.
 			d2.
 			d3 }.
-	cb popupListElement forceLayout.
-	cb selecter selectIndex: 1.
+		 cb selecter selectIndex: 1 .
+		cb manager popup ].
 	self assert: cb selecter selectedIndex equals: 1.
 	self assert: cb innerElement dataView children size equals: 1.
 
-	cb popupDataAccessor removeAll.
-	cb popupListElement forceLayout.
+	space deferAndSettle: [ cb popupDataAccessor removeAll ].
 	self assert: cb selecter selectedIndexes equals: {  }.
 	self assert: cb innerElement dataView children isEmpty
 ]
@@ -239,22 +243,25 @@ ToSingleSelectElementTest >> testWithStructuredData [
 
 	| cb d idx selectedData |
 	cb := ToSingleSelectElement new.
-	space root addChild: cb.
 	cb popupListElement nodeBuilder: [ :node :assoc :holder |
 		node addChild: (ToLabel text: assoc key) ].
 	cb dataViewBuilder: [ :dataItemView :assoc |
 		dataItemView addChild: (ToLabel text: assoc key) ].
-	cb popupListElement dataAccessor addAll: (d := {
-			      ('Bee Theme' -> ToBeeTheme).
-			      ('Raw Theme' -> ToRawTheme) }).
-	cb selecter selectIndex: 1.
-	self waitTestingSpaces.
+	d := {
+      ('Bee Theme' -> ToBeeTheme).
+      ('Raw Theme' -> ToRawTheme) }.
+
+	space deferAndSettle: [
+		space root addChild: cb.
+		cb popupListElement dataAccessor addAll: d.
+		cb selecter selectIndex: 1].
 	self assert: cb selectionModel selectedIndexesCount equals: 1.
 	idx := cb selectionModel selectedIndexes first.
 	selectedData := cb popupListElement dataAccessor at: idx.
 	self assert: selectedData value identicalTo: ToBeeTheme.
 	self assert: cb dataView firstChild text asString equals: d first key.
-	cb selecter selectIndex: 0.
+
+	space deferAndSettle: [ cb selecter selectIndex: 0 ].
 	self assert: cb selectionModel selectedIndexes isEmpty.
 	self assert: cb dataView children isEmpty
 ]

--- a/src/Toplo-Widget-Select/ToMultiSelectHeaderListElement.class.st
+++ b/src/Toplo-Widget-Select/ToMultiSelectHeaderListElement.class.st
@@ -47,7 +47,7 @@ ToMultiSelectHeaderListElement >> assertMaxSelectedCount: aNumber [
 ToMultiSelectHeaderListElement >> checkHideSelectionFromListElement [
 
 	selectElement hideSelected ifFalse: [ ^ self ].
-	self popupListElement inUIProcessDo: [ self popupListElement hideSelection ]
+	self popupListElement deferOrValue: [ self popupListElement hideSelection ]
 ]
 
 { #category : #'accessing - selection' }

--- a/src/Toplo-Widget-Select/ToSelectElement.class.st
+++ b/src/Toplo-Widget-Select/ToSelectElement.class.st
@@ -272,8 +272,13 @@ ToSelectElement >> sample: aDataItem [
 { #category : #'accessing - selection' }
 ToSelectElement >> selectedDataItems [
 
-	^ self selectionModel selectedIndexesCollect: [ :idx |
-		  self sieve originalData at: idx ]
+	| originalData |
+	originalData := self sieve originalData.
+
+	"The #select: guard safely reconciles selectionModel and originalData"
+	^ self selectionModel selectedIndexes
+		select: [ :idx | idx between: 1 and: originalData size ]
+		thenCollect: [ :idx | originalData at: idx ]
 ]
 
 { #category : #accessing }

--- a/src/Toplo-Widget-TabPane-Tests/ToTabGroupElementTest.class.st
+++ b/src/Toplo-Widget-TabPane-Tests/ToTabGroupElementTest.class.st
@@ -22,16 +22,14 @@ ToTabGroupElementTest >> itemCheckedBeforeAddedInSpace [
 	" in case of infinite element, the layout must be done, 
 	so it means that an item can't be selected before 
 	the tabGroup is added in a space "
-	self flag: 'Check if it is possible to avoid the layout '.
-	tabGroup itemList useInfiniteLayout ifTrue: [ tabGroup forceLayout ].
-
 	firstItem := tabGroup items first.
 	self deny: firstItem isSelected.
-	firstItem checked: true.
+	tabGroup itemList useInfiniteLayout
+		ifTrue: [ tabGroup selecter selectIndex: 1 ]
+		ifFalse: [ firstItem checked: true ].
 	self assert: firstItem isChecked.
 
-	space root addChild: tabGroup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: tabGroup ].
 	self assert: firstItem isSelected
 ]
 
@@ -39,25 +37,24 @@ ToTabGroupElementTest >> itemCheckedBeforeAddedInSpace [
 ToTabGroupElementTest >> itemSelectedBeforeAddedInSpace [
 
 	| firstItem |
-	tabGroup addItem: (ToTabItemElement new
+	tabGroup addItem:
+		(ToTabItemElement new
 			 id: #first;
 			 labelText: 'First';
 			 yourself).
 
+	firstItem := tabGroup items first.
+	self deny: firstItem isSelected.
+
 	" in case of infinite element, the layout must be done, 
 	so it means that an item can't be selected before 
 	the tabGroup is added in a space "
-	self flag: 'Check if it is possible to avoid the layout '.
-	tabGroup itemList useInfiniteLayout ifTrue: [ tabGroup forceLayout ].
-
-	firstItem := tabGroup items first.
-	self deny: firstItem isSelected.
 	tabGroup selecter selectIndex: 1.
-	self assert: firstItem isChecked.
-	self assert: firstItem isSelected.
+	tabGroup itemList useInfiniteLayout ifFalse: [
+		self assert: firstItem isChecked.
+		self assert: firstItem isSelected ].
 
-	space root addChild: tabGroup.
-	self waitTestingSpaces.
+	space deferAndSettle: [ space root addChild: tabGroup ].
 	self assert: firstItem isChecked.
 	self assert: firstItem isSelected
 ]
@@ -68,10 +65,7 @@ ToTabGroupElementTest >> setUp [
 	super setUp.
 	tabGroup := ToTabGroupElement new.
 	tabGroup matchParent.
-	space root addChild: tabGroup.
-	space root forceLayout.
-	self waitTestingSpaces 
-
+	space deferAndSettle: [ space root addChild: tabGroup ]
 ]
 
 { #category : #tests }
@@ -118,12 +112,10 @@ ToTabGroupElementTest >> testIsSelected [
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
 
-	self waitTestingSpaces.
 	self deny: firstItem isSelected.
 	self deny: secondItem isSelected.
 
-	BlSpace simulateClickOn: secondItem.
-	self waitTestingSpaces.
+	secondItem eventSimulator click.
 	self assert: secondItem isSelected.
 	self deny: firstItem isSelected
 ]
@@ -136,21 +128,19 @@ ToTabGroupElementTest >> testRemoveAllItems [
 	self withTwoTabItems.
 	firstButton := tabGroup items first.
 	secondButton := tabGroup items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true  ].
+	firstButton eventSimulator click.
 	self assert: firstButton isSelected.
 	self deny: secondButton isSelected.
-	tabGroup removeAllItems.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ tabGroup removeAllItems  ].
 	self assert: tabGroup items size equals: 0.
 	self assert: tabGroup itemList items size equals: 0.
 	self assert: tabGroup itemList innerElement nodeContainers size equals: 0.
 	" the fake node remains "
 	self assert: tabGroup itemList innerElement trackElement children size equals: 0
-
 ]
 
 { #category : #tests }
@@ -160,14 +150,13 @@ ToTabGroupElementTest >> testRemoveItem [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	tabGroup forceLayout.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true  ].
 	clicked := false.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpacesTimeout: 400 milliSeconds.
+	space deferAndSettle: [
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
 	secondItem removeButton
 		addEventHandlerOn: BlClickEvent
 		do: [ :evt | clicked := true ].
@@ -175,9 +164,10 @@ ToTabGroupElementTest >> testRemoveItem [
 	self assert: secondItem removeButton notNil.
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: secondItem removeButton.
-	BlSpace simulateClickOn: secondItem removeButton.
-	self waitTestingSpacesTimeout: 600 milliSeconds.
+	secondItem eventSimulator mouseMoveInside.
+	secondItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: clicked.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: firstItem
@@ -192,19 +182,20 @@ ToTabGroupElementTest >> testRemoveItem2 [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondItem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true.
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
+	secondItem eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: secondItem isSelected.
 	" after the click, the remove button should be visible "
-	BlSpace simulateMouseMoveInside: secondItem removeButton.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondItem removeButton.
-	self waitTestingSpacesTimeout: 600 milliSeconds.
+	secondItem eventSimulator mouseMoveInside.
+	secondItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: firstItem.
 	self assert: firstItem isSelected
@@ -219,22 +210,23 @@ ToTabGroupElementTest >> testRemoveItem3 [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstItem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true.
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
+	firstItem eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstItem isSelected.
 	" after the click, the remove button should be visible "
-	BlSpace simulateMouseMoveInside: firstItem removeButton.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstItem removeButton.
-	self waitTestingSpaces.
+	firstItem eventSimulator mouseMoveInside.
+	firstItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: secondItem.
-	self assert: secondItem isSelected.
+	self assert: secondItem isSelected
 ]
 
 { #category : #tests }
@@ -245,23 +237,25 @@ ToTabGroupElementTest >> testRemoveItem4 [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondItem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true.
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
+	secondItem eventSimulator
+		mouseMoveInside;
+		click.
 	self deny: firstItem isSelected.
 	self assert: secondItem isSelected.
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: secondItem removeButton.
-	BlSpace simulateClickOn: secondItem removeButton.
-	self waitTestingSpaces.
+	secondItem eventSimulator mouseMoveInside.
+	secondItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: firstItem.
-	self assert: firstItem isSelected.
+	self assert: firstItem isSelected
 ]
 
 { #category : #tests }
@@ -272,23 +266,25 @@ ToTabGroupElementTest >> testRemoveItem5 [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstItem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true.
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
+	firstItem eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstItem isSelected.
 	self deny: secondItem isSelected.
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: firstItem removeButton.
-	BlSpace simulateClickOn: firstItem removeButton.
-	self waitTestingSpaces.
+	firstItem eventSimulator mouseMoveInside.
+	firstItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: secondItem.
-	self assert: secondItem isSelected.
+	self assert: secondItem isSelected
 ]
 
 { #category : #tests }
@@ -299,49 +295,50 @@ ToTabGroupElementTest >> testRemoveItem6 [
 	self withTwoTabItems.
 	firstItem := tabGroup items first.
 	secondItem := tabGroup items second.
-	firstItem removable: true.
-	secondItem removable: true.
-	firstItem holder node addRemoveButton. 
-	secondItem holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstItem.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstItem removable: true.
+		secondItem removable: true.
+		firstItem holder node addRemoveButton. 
+		secondItem holder node addRemoveButton  ].
+	firstItem eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstItem isSelected.
 	self deny: secondItem isSelected.
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: firstItem removeButton.
-	BlSpace simulateClickOn: firstItem removeButton.
-	self waitTestingSpaces.
+	firstItem eventSimulator mouseMoveInside.
+	firstItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 1.
 	self assert: tabGroup items first identicalTo: secondItem.
 	self assert: secondItem isSelected.
 
 	firstItem := tabGroup items first.
-	BlSpace simulateMouseMoveInside: firstItem removeButton.
-	BlSpace simulateClickOn: firstItem removeButton.
-	self waitTestingSpaces.
+	firstItem eventSimulator mouseMoveInside.
+	firstItem removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabGroup items size equals: 0.
 	self assert: tabGroup itemList items size equals: 0.
 	self assert: tabGroup itemList innerElement nodeContainers size equals: 0.
 	" the fake node remains "
 	self assert: tabGroup itemList innerElement trackElement children size equals: 0
-
 ]
 
 { #category : #tests }
 ToTabGroupElementTest >> withTwoTabItems [
 
-	tabGroup addItem: (ToTabItemElement new
-			 id: #first;
-			 labelText: 'First';
-			 yourself).
-
-	tabGroup addItem: (ToTabItemElement new
-			 id: #second;
-			 labelText: 'Second';
-			 yourself).
-	self waitTestingSpaces.
-	tabGroup forceLayout.
-
+	space deferAndSettle: [
+		tabGroup addItem:
+			(ToTabItemElement new
+				 id: #first;
+				 labelText: 'First';
+				 yourself).
+		tabGroup addItem:
+			(ToTabItemElement new
+				 id: #second;
+				 labelText: 'Second';
+				 yourself) ]
 ]

--- a/src/Toplo-Widget-TabPane-Tests/ToTabListElementTest.class.st
+++ b/src/Toplo-Widget-TabPane-Tests/ToTabListElementTest.class.st
@@ -1,6 +1,3 @@
-"
-A ToTabListElementTest is a test class for testing the behavior of ToTabListElement
-"
 Class {
 	#name : #ToTabListElementTest,
 	#superclass : #ToParameterizedHostTest,
@@ -9,7 +6,7 @@ Class {
 		'tab1',
 		'tab2'
 	],
-	#category : #'Toplo-Widget-TabPane-Tests-TabList'
+	#category : #'Toplo-Widget-TabPane-Tests'
 }
 
 { #category : #running }
@@ -21,7 +18,7 @@ ToTabListElementTest >> setUp [
 	tabList vertical: true.
 	tabList vMatchParent.
 	tabList hFitContent.
-	space root addChild: tabList
+	space deferAndSettle: [ space root addChild: tabList ]
 ]
 
 { #category : #running }
@@ -32,35 +29,29 @@ ToTabListElementTest >> testAddOneItemAndSelect [
 	tab1 width: 200.
 	tab1 labelText: 'Hello'.
 
-	tabList addItem: tab1.
-	tab1 selected: true.
-
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		tabList addItem: tab1.
+		tab1 selected: true ].
 	self assert: tab1 isSelected.
 	self assert: tabList selectionModel selectedIndexesCount equals: 1.
 	self assert: tab1 isChecked
-
 ]
 
 { #category : #running }
 ToTabListElementTest >> testAddOneItemAndSelectAndDeselectAll [
 
 	self testAddOneItemAndSelect.
-	tabList selecter deselectAll.
-
-	self waitTestingSpaces.
+	space deferAndSettle: [ tabList selecter deselectAll ].
 	self assert: tabList selectionModel selectedIndexesCount equals: 0.
 	self deny: tab1 isSelected.
 	self deny: tab1 isChecked
-
 ]
 
 { #category : #running }
 ToTabListElementTest >> testAddSelectedItemAndDeselectAll [
 
 	self testAddTwoItemsAndSelect.
-	tabList selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tabList selecter deselectAll ].
 	self assert: tabList selectionModel selectedIndexesCount equals: 0
 ]
 
@@ -72,17 +63,16 @@ ToTabListElementTest >> testAddTwoItemsAndSelect [
 	tab1 width: 200.
 	tab1 labelText: 'Hello'.
 
-	tabList addItem: tab1.
-	tab1 selected: true.
-
 	tab2 := ToTabItemElement new.
 	tab2 beHorizontal.
 	tab2 width: 200.
 	tab2 labelText: 'Goodbye'.
 
-	tabList addItem: tab2.
-	tab2 selected: true.
-	self waitTestingSpaces.
+	space deferAndSettle: [ 
+		tabList addItem: tab1.
+		tab1 selected: true.
+		tabList addItem: tab2.
+		tab2 selected: true ].
 	self deny: tab1 isChecked.
 	self assert: tab2 isChecked.
 	self assert: tabList selectionModel selectedIndexesCount equals: 1

--- a/src/Toplo-Widget-TabPane-Tests/ToTabPaneElementTest.class.st
+++ b/src/Toplo-Widget-TabPane-Tests/ToTabPaneElementTest.class.st
@@ -21,17 +21,14 @@ ToTabPaneElementTest >> setUp [
 	tabPane := ToTabPaneElement new.
 	tabPane horizontal: true.
 	tabPane matchParent.
-	space root addChild: tabPane.
-	tabPane forceLayout.
-	self waitTestingSpaces.
-	BlSpace simulateMouseMoveInside: tabPane.
-
+	space deferAndSettle: [ space root addChild: tabPane  ].
+	tabPane eventSimulator mouseMoveInside.
+	space settle
 ]
 
 { #category : #tests }
 ToTabPaneElementTest >> testCheckTabButton [
 
-	tabPane := ToTabPaneElement new.
 	tabPane itemBuilder: [ :tabItem :data |
 			tabItem
 				id: data asSymbol;
@@ -42,9 +39,10 @@ ToTabPaneElementTest >> testCheckTabButton [
 									 matchParent;
 									 yourself) ] ].
 
-	tabPane addTabItemData: 'First'.
+	space deferAndSettle: [ tabPane addTabItemData: 'First' ].
 	self deny: tabPane items first isChecked.
-	tabPane items first checked: true.
+	
+	space deferAndSettle: [ tabPane items first checked: true ].
 	self assert: tabPane items first isChecked
 ]
 
@@ -53,25 +51,28 @@ ToTabPaneElementTest >> testCloseLastPage [
 
 	| firstButton secondButton clicked |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	tabPane forceLayout.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
 	clicked := false.
-	self waitTestingSpacesTimeout: 400 milliSeconds.
 	secondButton removeButton
 		addEventHandlerOn: BlClickEvent
 		do: [ :evt | clicked := true ].
 	self assert: tabPane items size equals: 2.
 	self assert: secondButton removeButton notNil.
+
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: secondButton removeButton.
-	BlSpace simulateClickOn: secondButton removeButton.
-	self waitTestingSpacesTimeout: 600 milliSeconds.
+	secondButton eventSimulator mouseMoveInside.
+	secondButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: clicked.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: firstButton
@@ -82,24 +83,28 @@ ToTabPaneElementTest >> testCloseSelectedPage [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	secondButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: secondButton isSelected.
+
 	" after the click, the remove button should be visible "
-	BlSpace simulateMouseMoveInside: secondButton removeButton.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondButton removeButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator mouseMoveInside.
+	secondButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: firstButton.
-	self assert: firstButton isSelected.
+	self assert: firstButton isSelected
 ]
 
 { #category : #tests }
@@ -107,31 +112,28 @@ ToTabPaneElementTest >> testCloseSelectedPage2 [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateMouseMoveInside: firstButton.
-	self waitTestingSpaces.
-	tabPane forceLayout.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	firstButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstButton isSelected.
+
 	" after the click, the remove button should be visible "
-	self waitTestingSpaces.
-	tabPane forceLayout.
-	BlSpace simulateMouseMoveInside: firstButton removeButton.
-	self waitTestingSpaces.
-	tabPane forceLayout.
-	BlSpace simulateClickOn: firstButton removeButton.
-	self waitTestingSpaces.
-	tabPane forceLayout.
+	firstButton eventSimulator mouseMoveInside.
+	firstButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: secondButton.
-	self assert: secondButton isSelected.
+	self assert: secondButton isSelected
 ]
 
 { #category : #tests }
@@ -140,29 +142,32 @@ ToTabPaneElementTest >> testCloseUnselectedPage [
 
 	| firstButton secondButton clicked |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	clicked := false.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	tabPane forceLayout.
-	self waitTestingSpacesTimeout: 400 milliSeconds.
-	firstButton removeButton addEventHandlerOn: BlClickEvent do: [ :evt | clicked := true ].
-	BlSpace simulateMouseMoveInside: firstButton.
-	self waitTestingSpacesTimeout: 400 milliSeconds.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	firstButton removeButton
+		addEventHandlerOn: BlClickEvent
+		do: [ :evt | clicked := true ].
+	firstButton eventSimulator mouseMoveInside.
 	self deny: firstButton isSelected.
 	self deny: secondButton isSelected.
+
 	" after the click, the remove button should be visible "
-	BlSpace simulateMouseMoveInside: firstButton removeButton.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton removeButton.
-	self waitTestingSpacesTimeout: 400 milliSeconds.
+	firstButton eventSimulator mouseMoveInside.
+	firstButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: clicked.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: secondButton.
-	self deny: secondButton isSelected.
+	self deny: secondButton isSelected
 ]
 
 { #category : #tests }
@@ -171,25 +176,30 @@ ToTabPaneElementTest >> testCloseUnselectedPage2 [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	firstButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstButton isSelected.
 	self deny: secondButton isSelected.
+
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: secondButton removeButton.
-	BlSpace simulateClickOn: secondButton removeButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator mouseMoveInside.
+	secondButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: firstButton.
-	self assert: firstButton isSelected.
+	self assert: firstButton isSelected
 ]
 
 { #category : #tests }
@@ -198,25 +208,30 @@ ToTabPaneElementTest >> testCloseUnselectedPage3 [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	secondButton eventSimulator
+		mouseMoveInside;
+		click.
 	self deny: firstButton isSelected.
 	self assert: secondButton isSelected.
+
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: secondButton removeButton.
-	BlSpace simulateClickOn: secondButton removeButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator mouseMoveInside.
+	secondButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: firstButton.
-	self assert: firstButton isSelected.
+	self assert: firstButton isSelected
 ]
 
 { #category : #tests }
@@ -225,26 +240,30 @@ ToTabPaneElementTest >> testCloseUnselectedPage4 [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	firstButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstButton isSelected.
 	self deny: secondButton isSelected.
+
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: firstButton removeButton.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton removeButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator mouseMoveInside.
+	firstButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: secondButton.
-	self assert: secondButton isSelected.
+	self assert: secondButton isSelected
 ]
 
 { #category : #tests }
@@ -253,30 +272,35 @@ ToTabPaneElementTest >> testCloseUnselectedPage5 [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	firstButton holder node addRemoveButton. 
-	secondButton holder node  addRemoveButton. 
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true.
+		firstButton holder node addRemoveButton. 
+		secondButton holder node addRemoveButton ].
+
+	firstButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: firstButton isSelected.
 	self deny: secondButton isSelected.
 	" one have first to ensure that the remove button is visible 
 	(with Raw skin, the remove button is only visible when the mouse is over its tab button) "
-	BlSpace simulateMouseMoveInside: firstButton removeButton.
-	BlSpace simulateClickOn: firstButton removeButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator mouseMoveInside.
+	firstButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 1.
 	self assert: tabPane items first identicalTo: secondButton.
 	self assert: secondButton isSelected.
 
 	firstButton := tabPane items first.
-	BlSpace simulateMouseMoveInside: firstButton removeButton.
-	BlSpace simulateClickOn: firstButton removeButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator mouseMoveInside.
+	firstButton removeButton eventSimulator
+		mouseMoveInside;
+		click.
 	self assert: tabPane items size equals: 0.
 	self assert: tabPane body children isEmpty
 ]
@@ -289,12 +313,10 @@ ToTabPaneElementTest >> testIsSelected [
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
 
-	self waitTestingSpaces.
 	self deny: firstButton isSelected.
 	self deny: secondButton isSelected.
 
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator click.
 	self assert: secondButton isSelected.
 	self deny: firstButton isSelected
 ]
@@ -307,27 +329,22 @@ ToTabPaneElementTest >> testPaneBuilderIsValuedOnSelect [
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
 	
-	self waitTestingSpaces.
 	self assert: firstTabBuildCount equals: 0.
 	self assert: secondTabBuildCount equals: 0.
 	
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator click.
 	self assert: firstTabBuildCount equals: 0.
 	self assert: secondTabBuildCount equals: 1.
 
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator click.
 	self assert: firstTabBuildCount equals: 1.
 	self assert: secondTabBuildCount equals: 1.
 
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator click.
 	self assert: firstTabBuildCount equals: 1.
 	self assert: secondTabBuildCount equals: 1.
 
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator click.
 	self assert: firstTabBuildCount equals: 1.
 	self assert: secondTabBuildCount equals: 1
 ]
@@ -339,24 +356,21 @@ ToTabPaneElementTest >> testPaneBuilderIsValuedOnSelect2 [
 	self withTwoTabButtons.
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton destroyPaneWhenDeselected: true.
-	secondButton destroyPaneWhenDeselected: true.
+	space deferAndSettle: [
+		firstButton destroyPaneWhenDeselected: true.
+		secondButton destroyPaneWhenDeselected: true ].
 	
-	self waitTestingSpaces.
-	
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator click.
 
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator click.
 
-	BlSpace simulateClickOn: secondButton.
-	self waitTestingSpaces.
+	secondButton eventSimulator click.
+
 	self assert: firstTabBuildCount equals: 1.
 	self assert: secondTabBuildCount equals: 2.
 
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	firstButton eventSimulator click.
+
 	self assert: firstTabBuildCount equals: 2.
 	self assert: secondTabBuildCount equals: 2
 ]
@@ -367,28 +381,26 @@ ToTabPaneElementTest >> testRemoveAllItems [
 
 	| firstButton secondButton |
 	self withTwoTabButtons.
+
 	firstButton := tabPane items first.
 	secondButton := tabPane items second.
-	firstButton removable: true.
-	secondButton removable: true.
-	self waitTestingSpaces.
-	BlSpace simulateClickOn: firstButton.
-	self waitTestingSpaces.
+	space deferAndSettle: [
+		firstButton removable: true.
+		secondButton removable: true ].
+
+	firstButton eventSimulator click.
 	self assert: firstButton isSelected.
 	self deny: secondButton isSelected.
 	self assert: tabPane body children notEmpty.
-	tabPane removeAllItems.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ tabPane removeAllItems ].
 	self assert: tabPane items size equals: 0.
-	self assert: tabPane body children isEmpty.
-
-
+	self assert: tabPane body children isEmpty
 ]
 
 { #category : #tests }
 ToTabPaneElementTest >> testSelectTabButton [
 
-	tabPane := ToTabPaneElement new.
 	tabPane itemBuilder: [ :tabItem :data |
 			tabItem
 				id: data asSymbol;
@@ -399,35 +411,40 @@ ToTabPaneElementTest >> testSelectTabButton [
 									 matchParent;
 									 yourself) ] ].
 
-	tabPane addTabItemData: 'First'.
+	space deferAndSettle: [ tabPane addTabItemData: 'First' ].
 	self deny: tabPane items first isChecked.
-	tabPane selecter selectIndex: 1.
+
+	space deferAndSettle: [ tabPane selecter selectIndex: 1 ].
 	self assert: tabPane items first isChecked
 ]
 
 { #category : #tests }
 ToTabPaneElementTest >> withTwoTabButtons [
 
-	tabPane addItem: (ToTabButton new
-			 id: #first;
-			 labelText: 'First';
-			 paneBuilder: [ :body :btn :holder |
+	space deferAndSettle: [
+		tabPane addItem:
+			(ToTabButton new
+				 id: #first;
+				 labelText: 'First';
+				 paneBuilder: [ :body :btn :holder |
 					 firstTabBuildCount := firstTabBuildCount + 1.
-					 body addChild: (ToElement new
-								  background: Color red;
-								  matchParent;
-								  yourself) ];
-			 yourself).
+					 body addChild:
+						(ToElement new
+							background: Color red;
+							matchParent;
+							yourself) ];
+				 yourself).
 
-	tabPane addItem: (ToTabButton new
-			 id: #second;
-			 labelText: 'Second';
-			 paneBuilder: [ :body :btn :holder |
-					 secondTabBuildCount := secondTabBuildCount + 1.
-					 body addChild: (ToElement new
-								  background: Color green;
-								  matchParent;
-								  yourself) ];
-			 yourself).
-	self waitTestingSpaces 
+		tabPane addItem:
+			(ToTabButton new
+				 id: #second;
+				 labelText: 'Second';
+				 paneBuilder: [ :body :btn :holder |
+						secondTabBuildCount := secondTabBuildCount + 1.
+						body addChild:
+							(ToElement new
+								background: Color green;
+								matchParent;
+								yourself) ];
+				 yourself) ]
 ]

--- a/src/Toplo-Widget-Table-Tests/ToTableElementTest.class.st
+++ b/src/Toplo-Widget-Table-Tests/ToTableElementTest.class.st
@@ -15,7 +15,6 @@ ToTableElementTest >> setUp [
 
 	super setUp.
 	table := ToTableElement new.
-	space root addChild: table.
 	table columns: {
 			(ToTableColumn new
 				 title: 'Name';
@@ -29,14 +28,16 @@ ToTableElementTest >> setUp [
 				 yourself) }.
 	table dataAccessor addAll:
 		(Smalltalk globals allClasses copyFrom: 1 to: 3).
-	self waitTestingSpaces
+
+	space deferAndSettle: [ space root addChild: table ]
 ]
 
 { #category : #running }
 ToTableElementTest >> testAddColumn [
 
 	| rows |
-	table columns: {
+	space deferAndSettle: [
+		table columns: {
 			(ToTableColumn new
 				 title: 'Name 2';
 				 key: 'name';
@@ -51,9 +52,11 @@ ToTableElementTest >> testAddColumn [
 				 title: 'Number of variables 2';
 				 key: 'variables';
 				 dataIndex: 'numberOfVariables';
-				 yourself) }.
-	self waitTestingSpaces.
-	self assert: (table header) nodeContainer middleContainer children size equals: 3.
+				 yourself) } ].
+	self
+		assert: table header nodeContainer middleContainer children size
+		equals: 3.
+
 	rows := table selectChildrenWithId: #row.
 	self assert: rows isNotEmpty.
 	rows do: [ :row | self assert: row children size equals: 3 ]
@@ -63,9 +66,9 @@ ToTableElementTest >> testAddColumn [
 ToTableElementTest >> testAddElementInData [
 
 	self assert: (table selectChildrenWithId: #row) size equals: 3.
-	table dataAccessor addAll:
-		(Smalltalk globals allClasses copyFrom: 4 to: 6).
-	self waitTestingSpaces.
+
+	space deferAndSettle: [
+		table dataAccessor addAll: { Number. Float. Integer } ].
 	self assert: (table selectChildrenWithId: #row) size equals: 6
 ]
 

--- a/src/Toplo-Widget-Table-Tests/ToTreeTableElementTest.class.st
+++ b/src/Toplo-Widget-Table-Tests/ToTreeTableElementTest.class.st
@@ -21,8 +21,9 @@ ToTreeTableElementTest >> setUp [
 	tree nodeManager childrenGetter: [ :dataItem |
 			Array streamContents: [ :stream |
 				dataItem do: [ :c | stream nextPut: c asSymbol ] ] ].
-	tree dataAccessor addAll: { #AAA. #BBB. #CCC }.
-	space root addChild: tree
+	space deferAndSettle: [
+		tree dataAccessor addAll: { #AAA. #BBB. #CCC }.
+		space root addChild: tree ]
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -31,14 +32,14 @@ ToTreeTableElementTest >> testCollapse [
 
 	| wrapper size |
 	"get the second node wrapper"
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
-	wrapper collapse.
+	space deferAndSettle: [
+		wrapper expand.
+		wrapper collapse ].
 	self deny: wrapper isExpanded.
-	self assert: tree dataSource size equals: size.
-	^ wrapper
+	self assert: tree dataSource size equals: size
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -48,20 +49,22 @@ ToTreeTableElementTest >> testCollapseWithSelectionBeforeCollapsedWrapper [
 
 	| selChangedEvent wrapper size |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 1 ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
+
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
+
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: selChangedEvent isNil.
 	self assert: tree selecter selectedIndexes equals: { 1 }.
 	selChangedEvent := nil.
-	wrapper collapse.
+
+	space deferAndSettle: [ wrapper collapse ].
 	self assert: wrapper isCollapsed.
 	self assert: selChangedEvent isNil.
 	self assert: tree selecter selectedIndexes equals: { 1 }
@@ -72,15 +75,15 @@ ToTreeTableElementTest >> testExpand [
 
 	" the data source size increases when expanding a wrapper  "
 	| wrapper size |
+
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
+
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
-	self assert: tree dataSource size equals: size + 3.
-	^ wrapper
-
+	self assert: tree dataSource size equals: size + 3
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -91,11 +94,13 @@ ToTreeTableElementTest >> testExpandWithEmptySelection [
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
+
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
+
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
 	self assert: tree dataSource size equals: size + 3.
 	self assert: selChangedEvent isNil
@@ -106,16 +111,15 @@ ToTreeTableElementTest >> testExpandWithSelectionBeforeExpandedWrapper [
 
 	| selChangedEvent wrapper size |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 1 ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
 	self assert: tree dataSource size equals: size + 3.
 	self assert: selChangedEvent isNil.

--- a/src/Toplo-Widget-Tree-Tests/ToTreeElementTest.class.st
+++ b/src/Toplo-Widget-Tree-Tests/ToTreeElementTest.class.st
@@ -15,8 +15,9 @@ ToTreeElementTest >> setUp [
 	tree childrenGetter: [ :dataItem |
 			Array streamContents: [ :stream |
 				dataItem do: [ :c | stream nextPut: c asSymbol ] ] ].
-	tree dataAccessor addAll: { #AAA. #BBB. #CCC }.
-	space root addChild: tree
+	space deferAndSettle: [
+		tree dataAccessor addAll: { #AAA. #BBB. #CCC }.
+		space root addChild: tree ]
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -25,14 +26,14 @@ ToTreeElementTest >> testCollapse [
 
 	| wrapper size |
 	"get the second node wrapper"
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
-	wrapper collapse.
+	space deferAndSettle: [
+		wrapper expand.
+		wrapper collapse ].
 	self deny: wrapper isExpanded.
-	self assert: tree dataSource size equals: size.
-	^ wrapper
+	self assert: tree dataSource size equals: size
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -42,31 +43,25 @@ ToTreeElementTest >> testCollapseWithDirectCollapsedWrapperChildrenSelected [
 	has selected children "
 	| selChangedEvent wrapper |
 	selChangedEvent := nil.
-	tree selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter deselectAll ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
-	wrapper expand.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper expand ].
 	" selection of the first expanded wrapper child "
 	self assert: tree selecter selectedIndexes equals: {  }.
 	selChangedEvent := nil.
-	tree selecter selectIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 3 ].
 	self assert: tree selecter selectedIndexes equals: { 3 }.
 	self assert: selChangedEvent notNil.
 	selChangedEvent := nil.
-	wrapper collapse.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper collapse ].
 	self assert: selChangedEvent notNil.
 	self assert: selChangedEvent selectedIndexes equals: {  }.
-	self assert: tree selecter selectedIndexes equals: {  }.
-	
-	
+	self assert: tree selecter selectedIndexes equals: {  }
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -75,8 +70,7 @@ ToTreeElementTest >> testCollapseWithSelectionAfterCollapsedWrapper [
 
 	| selChangedEvent wrapper size count |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 3 ].
 	count := 0.
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
@@ -84,17 +78,15 @@ ToTreeElementTest >> testCollapseWithSelectionAfterCollapsedWrapper [
 				count := count + 1.
 				selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: count equals: 1.
 	self assert: selChangedEvent notNil.
 	self assert: tree selecter selectedIndexes equals: { 6 }.
 	selChangedEvent := nil.
-	wrapper collapse.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper collapse ].
 	self assert: wrapper isCollapsed.
 	self assert: count equals: 2.
 	self assert: selChangedEvent notNil.
@@ -108,20 +100,19 @@ ToTreeElementTest >> testCollapseWithSelectionBeforeCollapsedWrapper [
 
 	| selChangedEvent wrapper size |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 1 ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: selChangedEvent isNil.
 	self assert: tree selecter selectedIndexes equals: { 1 }.
 	selChangedEvent := nil.
-	wrapper collapse.
+	space deferAndSettle: [ wrapper collapse ].
 	self assert: wrapper isCollapsed.
 	self assert: selChangedEvent isNil.
 	self assert: tree selecter selectedIndexes equals: { 1 }
@@ -134,30 +125,27 @@ ToTreeElementTest >> testCollapseWithSubSubCollapsedWrapperChildrenSelected [
 
 	| selChangedEvent wrapper subWrapper |
 	selChangedEvent := nil.
-	tree selecter deselectAll.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter deselectAll ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	"get the expanded wrapper first child wrapper"
-	subWrapper := tree dataSource at: 3.
+	subWrapper := tree dataSource third.
 	self assert: subWrapper parentWrapper equals: wrapper.
-	subWrapper expand.
-	self waitTestingSpaces.
+
+	space deferAndSettle: [ subWrapper expand ].
 	" selection of the first child wrapper of the subwrapper "
-	self assert: (tree dataSource at: 4) parentWrapper equals: subWrapper.
+	self assert: tree dataSource fourth parentWrapper equals: subWrapper.
 	selChangedEvent := nil.
-	tree selecter selectIndex: 4.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 4 ].
 	self assert: selChangedEvent notNil.
 	self assert: tree selecter selectedIndexes equals: { 4 }.
 	selChangedEvent := nil.
-	wrapper collapse.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper collapse ].
 	self assert: selChangedEvent notNil.
 	self assert: selChangedEvent selectedIndexes equals: {  }.
 	self assert: tree selecter selectedIndexes equals: {  }
@@ -169,14 +157,12 @@ ToTreeElementTest >> testExpand [
 	" the data source size increases when expanding a wrapper  "
 	| wrapper size |
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
-	self assert: tree dataSource size equals: size + 3.
-	^ wrapper
-
+	self assert: tree dataSource size equals: size + 3
 ]
 
 { #category : #'expanding-collapsing tests' }
@@ -188,10 +174,10 @@ ToTreeElementTest >> testExpandWithEmptySelection [
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
 	self assert: tree dataSource size equals: size + 3.
 	self assert: selChangedEvent isNil
@@ -202,8 +188,7 @@ ToTreeElementTest >> testExpandWithSelectionAfterExpandedWrapper [
 
 	| selChangedEvent wrapper size count |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 3.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 3 ].
 	count := 0.
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
@@ -211,11 +196,10 @@ ToTreeElementTest >> testExpandWithSelectionAfterExpandedWrapper [
 				count := count + 1.
 				selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
-	self waitTestingSpaces.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
 	self assert: tree dataSource size equals: size + 3.
 	self assert: count equals: 1.
@@ -228,16 +212,15 @@ ToTreeElementTest >> testExpandWithSelectionBeforeExpandedWrapper [
 
 	| selChangedEvent wrapper size |
 	selChangedEvent := nil.
-	tree selecter selectIndex: 1.
-	self waitTestingSpaces.
+	space deferAndSettle: [ tree selecter selectIndex: 1 ].
 	tree
 		addEventHandlerOn: ToListPrimarySelectionChangedEvent
 		do: [ :event | selChangedEvent := event ].
 	" get the second node wrapper "
-	wrapper := tree dataSource at: 2.
+	wrapper := tree dataSource second.
 	"expand it, then no event should be dispateched"
 	size := tree dataSource size.
-	wrapper expand.
+	space deferAndSettle: [ wrapper expand ].
 	self assert: wrapper isExpanded.
 	self assert: tree dataSource size equals: size + 3.
 	self assert: selChangedEvent isNil.

--- a/src/Toplo/BlElement.extension.st
+++ b/src/Toplo/BlElement.extension.st
@@ -376,17 +376,36 @@ BlElement >> hasAllStamps: aSymbolCollection [
 ]
 
 { #category : #'*Toplo' }
+BlElement >> hasEnqueuedStates [
+
+	self skinManagerDo: [ :sm | 
+		sm skinStateQueue nextStates ifNotEmpty: [ ^ true ] ].
+	self childrenDo: [ :child | 
+		child hasEnqueuedStates ifTrue: [ ^ true ] ].
+	^ false
+]
+
+{ #category : #'*Toplo' }
 BlElement >> hasFocusedParent [
 
 	^ self isFocused or: [
-		  self parent notNil and: [ 
-			  self parent isRoot not and: [ self parent hasFocusedParent ] ] ]
+		self hasParent and: [ self parent isRoot not and: [ self parent hasFocusedParent ] ] ]
 ]
 
 { #category : #'*Toplo' }
 BlElement >> hasListHolder [
 
 	^ self constraints hasListHolder
+]
+
+{ #category : #'*Toplo' }
+BlElement >> hasNewSkinRequested [
+
+	self skinManagerDo: [ :sm | 
+		sm newSkinRequested ifTrue: [ ^ true ] ].
+	self childrenDo: [ :child | 
+		child hasNewSkinRequested ifTrue: [ ^ true ] ].
+	^ false
 ]
 
 { #category : #'*Toplo' }
@@ -756,7 +775,7 @@ BlElement >> requestNewSkin [
 { #category : #'*Toplo' }
 BlElement >> requestSkinApplication [
 
-	self spaceDo: [ :sp | sp requestNextPulse ]
+	self spaceDo: [ :sp | sp requestPulse ]
 ]
 
 { #category : #'*Toplo' }

--- a/src/Toplo/BlSpace.extension.st
+++ b/src/Toplo/BlSpace.extension.st
@@ -54,14 +54,14 @@ BlSpace >> needSkinInstallPass [
 BlSpace >> needSkinInstallPass: aBoolean [
 
 	self phasesManager needSkinInstallPass: aBoolean.
-	aBoolean ifTrue: [ self requestNextPulse ]
+	aBoolean ifTrue: [ self requestPulse ]
 ]
 
 { #category : #'*Toplo' }
 BlSpace >> needSkinStateApplicationPass: aBoolean [
 
 	self phasesManager needSkinStateApplicationPass: aBoolean.
-	aBoolean ifTrue: [ self requestNextPulse ]
+	aBoolean ifTrue: [ self requestPulse ]
 ]
 
 { #category : #'*Toplo' }
@@ -80,7 +80,7 @@ BlSpace >> phasesManager [
 BlSpace >> requestNewConfigurationPass [
 
 	self phasesManager requestNewConfigurationPass.
-	self requestNextPulse 
+	self requestPulse 
 ]
 
 { #category : #'*Toplo' }

--- a/src/Toplo/TToEventGeneratorHandler.trait.st
+++ b/src/Toplo/TToEventGeneratorHandler.trait.st
@@ -135,5 +135,6 @@ TToEventGeneratorHandler >> taskActionFromEvent: anEvent in: aTarget [
 					       sourceEvent: anEvent copy;
 					       yourself ].
 	aTarget dispatchEvent: evt.
-	evt isConsumed ifTrue: [ self stopTaskFromEvent: anEvent in: aTarget ]
+	evt isConsumed ifTrue: [ self stopTaskFromEvent: anEvent in: aTarget ].
+	needRepeatedEvent ifFalse: [ self cleanUpCheckerIn: aTarget ]
 ]

--- a/src/Toplo/ToActionLink.class.st
+++ b/src/Toplo/ToActionLink.class.st
@@ -75,7 +75,7 @@ ToActionLink >> requestNextRunWithEvent: anEvent [
 	widget isAttachedToSceneGraph
 		ifTrue: [ self onNextRunActionRequest: anEvent ]
 		ifFalse: [
-		widget inUIProcessDo: [ self onNextRunActionRequest: anEvent ] ]
+		widget deferOrValue: [ self onNextRunActionRequest: anEvent ] ]
 ]
 
 { #category : #running }

--- a/src/Toplo/ToElementInitializeEventHandler.class.st
+++ b/src/Toplo/ToElementInitializeEventHandler.class.st
@@ -24,7 +24,7 @@ ToElementInitializeEventHandler >> elementAddedToSceneGraphEvent: anEvent [
 	target := anEvent currentTarget.
 	target applyConfiguration.
 	target ensuredSkinManager requestNewSkinIn: target.
-	target space checkToploPhases.
+	target spaceDo: [ :sp | sp checkToploPhases ].
 	target dispatchEvent: ToAddedToSpaceEvent new
 ]
 

--- a/src/Toplo/ToPopupWindowManager.class.st
+++ b/src/Toplo/ToPopupWindowManager.class.st
@@ -204,6 +204,7 @@ ToPopupWindowManager >> isPopover [
 ToPopupWindowManager >> mouseDownEvent: anEvent [
 	" first I have to test if I'am concerned by this event "
 
+	popupOnPressed ifFalse: [ ^ self ].
 	anEvent button = mouseButton ifFalse: [ ^ self ].
 	currentWindow ifNotNil: [ " use case: the mouse is on a menu button and the menu window is opened. 
 		clicking on this menu button must close the button and cancel the pane auto open"

--- a/src/Toplo/ToSkinStateGenerator.class.st
+++ b/src/Toplo/ToSkinStateGenerator.class.st
@@ -24,6 +24,7 @@ ToSkinStateGenerator class >> handledUIEvents [
 		  BlMouseUpEvent.
 		  BlMouseEnterEvent.
 		  BlMouseLeaveEvent.
+		  BlElementAddedToSceneGraphEvent.
 		  ToMouseUpOutsideEvent }
 ]
 
@@ -151,6 +152,17 @@ ToSkinStateGenerator >> dropEvent: anEvent [
 
 	target isEnabled ifFalse: [ ^ self ].
 	self enqueueTransientState: (ToDroppedSkinEvent sourceEvent: anEvent)
+]
+
+{ #category : #'event handling' }
+ToSkinStateGenerator >> elementAddedToSceneGraphEvent: anEvent [
+
+	| elem |
+	elem := anEvent target.
+	elem hasNewSkinRequested ifTrue: [
+		elem spaceDo: [ :sp | sp phasesManager needSkinInstallPass: true ] ].
+	elem hasEnqueuedStates ifTrue: [
+		elem spaceDo: [ :sp | sp phasesManager needSkinStateApplicationPass: true ] ]
 ]
 
 { #category : #'state generating' }

--- a/src/Toplo/ToSpaceConfigurationPhase.class.st
+++ b/src/Toplo/ToSpaceConfigurationPhase.class.st
@@ -4,9 +4,15 @@ Class {
 	#category : #'Toplo-Core-SpaceFrame'
 }
 
+{ #category : #testing }
+ToSpaceConfigurationPhase >> isSettledIn: aSpace [
+	"Return true if aSpace does not need a configuration pass"
+
+	^ aSpace phasesManager needConfigurationPass not
+]
+
 { #category : #accessing }
 ToSpaceConfigurationPhase >> name [
-	<return: #String>
 	
 	^ 'Configuration phase'
 ]

--- a/src/Toplo/ToSpaceSkinInstallerPhase.class.st
+++ b/src/Toplo/ToSpaceSkinInstallerPhase.class.st
@@ -4,9 +4,16 @@ Class {
 	#category : #'Toplo-Core-SpaceFrame'
 }
 
+{ #category : #testing }
+ToSpaceSkinInstallerPhase >> isSettledIn: aSpace [
+	"Return true if aSpace does not need a skin installation pass"
+
+	^ aSpace phasesManager needSkinInstallPass not
+		and: [ aSpace root hasNewSkinRequested not ]
+]
+
 { #category : #accessing }
 ToSpaceSkinInstallerPhase >> name [
-	<return: #String>
 	
 	^ 'Skin installer phase'
 ]

--- a/src/Toplo/ToSpaceSkinStateApplicationPhase.class.st
+++ b/src/Toplo/ToSpaceSkinStateApplicationPhase.class.st
@@ -4,9 +4,16 @@ Class {
 	#category : #'Toplo-Core-SpaceFrame'
 }
 
+{ #category : #testing }
+ToSpaceSkinStateApplicationPhase >> isSettledIn: aSpace [
+	"Return true if aSpace does not need a skin state application pass"
+
+	^ aSpace phasesManager needSkinStateApplicationPass not
+		and: [ aSpace root hasEnqueuedStates not ]
+]
+
 { #category : #accessing }
 ToSpaceSkinStateApplicationPhase >> name [
-	<return: #String>
 	
 	^ 'Skin state phase'
 ]

--- a/src/Toplo/ToWorldMenu.class.st
+++ b/src/Toplo/ToWorldMenu.class.st
@@ -14,7 +14,7 @@ ToWorldMenu class >> menuCleanUpUniverseOn: aBuilder [
 		label: 'Cleanup Universe';
 		help: 'Close all spaces then restart the underlying host';
 		iconName: #smallDebug;
-		action: [ Toplo closeAllSpaces ]
+		action: [ Toplo closeSpaces ]
 ]
 
 { #category : #'menu - toplo' }

--- a/src/Toplo/Toplo.class.st
+++ b/src/Toplo/Toplo.class.st
@@ -18,14 +18,17 @@ Toplo class >> announcer [
 { #category : #initialization }
 Toplo class >> closeAllSpaces [
 
-	BlOSWindowSDL2Host universe closeSpaces.
-	BlOSWindowSDL2Host
-		stop;
-		start.
-	BlMorphicWindowHost universe closeSpaces.
-	BlMorphicWindowHost
-		stop;
-		start
+	self
+		deprecated: 'Use #closeSpaces instead'
+		transformWith: '`@receiver closeAllSpaces' -> '`@receiver closeSpaces'.
+
+	self closeSpaces
+]
+
+{ #category : #initialization }
+Toplo class >> closeSpaces [
+
+	Bloc closeSpaces
 ]
 
 { #category : #settings }


### PR DESCRIPTION
This PR updates Toplo to work with the new Bloc concurrency and pulse synchronization changes. It allows Toplo's custom space frame phases (skins, states, configurations) to participate in `#settle` and `#deferAndSettle:`, and updates tests to avoid timing issues:

- Implement `#isSettledIn:` in Toplo frame phases to ensure that `space settle` and `space deferAndSettle:` wait while Toplo skin installations, state queues, or configuration passes are still pending.
- Migrated tests across lists, tabs, menus, tooltips, windows, and themes to use `deferAndSettle:`, `settle`, and `eventSimulator`.

Related Issues:
- https://github.com/pharo-graphics/Toplo/issues/297 (Error during ToSpaceConfigurationPhase)
- https://github.com/pharo-graphics/Toplo/issues/397 (Checkbox ignores second click on rapid double click)
- https://github.com/pharo-graphics/Toplo/issues/399 (Space root focus causes child elements to miss ToFocusedSkinEvent)
