### PR TITLE
Clean up tests

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -13,8 +13,8 @@ jobs:
       # Default value means that a failure in one OS cancels all 
       fail-fast: false
       matrix:
-        smalltalk: [ Pharo64-13, Pharo64-14, Pharo64-15 ]
-        os: [ macos-latest ]
+        smalltalk: [ Pharo64-14, Pharo64-15 ]
+        os: [ macos-latest, windows-latest ]
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.smalltalk }} on ${{ matrix.os }}
     steps:

--- a/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
+++ b/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
@@ -168,8 +168,7 @@ TToElementWithContextMenuTest >> testCurrentContextMenu [
 		menu addAllItems: { ToMenuItem new } ].
 	self assert: e hasContextMenu.
 	self assert: e currentContextMenu notNil.
-	self assert: e currentContextMenu identicalTo: ttwin.
-	^ e
+	self assert: e currentContextMenu identicalTo: ttwin
 ]
 
 { #category : #tests }
@@ -184,8 +183,7 @@ TToElementWithContextMenuTest >> testCurrentContextMenu2 [
 	self assert: e currentContextMenu notNil.
 	self
 		assert: e currentContextMenu class
-		equals: e ensuredContextMenuManager windowClass.
-	^ e
+		equals: e ensuredContextMenuManager windowClass
 ]
 
 { #category : #tests }
@@ -207,8 +205,7 @@ TToElementWithContextMenuTest >> testEnsuredContextMenuManager [
 
 	space deferAndSettle: [ ttwin close ].
 	self assert: e ensuredContextMenuManager currentWindow isNil.
-	self assert: e ensuredContextMenuManager anchorElement identicalTo: e.
-	^ e
+	self assert: e ensuredContextMenuManager anchorElement identicalTo: e
 ]
 
 { #category : #tests }
@@ -238,8 +235,7 @@ TToElementWithContextMenuTest >> testNewContextMenu [
 	self assert: e currentContextMenu notNil.
 	self
 		assert: e currentContextMenu class
-		equals: e ensuredContextMenuManager windowClass.
-	^ e
+		equals: e ensuredContextMenuManager windowClass
 ]
 
 { #category : #tests }
@@ -256,8 +252,7 @@ TToElementWithContextMenuTest >> testNewContextMenuOnEvent [
 	self assert: e ensuredContextMenuManager currentWindow notNil.
 	self
 		assert: e currentContextMenu
-		identicalTo: e ensuredContextMenuManager currentWindow.
-	^ e
+		identicalTo: e ensuredContextMenuManager currentWindow
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
+++ b/src/Toplo-Tests/TToElementWithContextMenuTest.class.st
@@ -4,6 +4,16 @@ Class {
 	#category : #'Toplo-Tests-Core'
 }
 
+{ #category : #helpers }
+TToElementWithContextMenuTest >> newElementWithContextMenuBuilder [
+
+	| e |
+	e := ToElement new.
+	e contextMenuBuilder: [ :menu :request |
+		menu addAllItems: { ToMenuItem new } ].
+	^ e
+]
+
 { #category : #tests }
 TToElementWithContextMenuTest >> testContextMenu [
 
@@ -24,8 +34,7 @@ TToElementWithContextMenuTest >> testContextMenu [
 	self assert: ttwin root firstChild nodes first item identicalTo: tt.
 	self assert: ttwin anchorElement identicalTo: e.
 
-	space deferAndSettle: [ ttwin close ].
-	^ e
+	space deferAndSettle: [ ttwin close ]
 ]
 
 { #category : #tests }
@@ -81,7 +90,8 @@ TToElementWithContextMenuTest >> testContextMenuBuilder [
 TToElementWithContextMenuTest >> testContextMenuBuilder2 [
 
 	| e ttwin |
-	e := self testContextMenu.
+	e := self newElementWithContextMenuBuilder.
+	space deferAndSettle: [ space root addChild: e ].
 	self assert: e ensuredContextMenuManager currentWindow isNil.
 
 	space deferAndSettle: [
@@ -159,7 +169,7 @@ TToElementWithContextMenuTest >> testContextMenuRequest [
 TToElementWithContextMenuTest >> testCurrentContextMenu [
 
 	| e ttwin |
-	e := self testHasContextMenu.
+	e := self newElementWithContextMenuBuilder.
 	self assert: e currentContextMenu isNil.
 	self assert: (e eventDispatcher hasEventHandlerSuchThat: [ :eh |
 			 eh isKindOf: ToContextMenuManager ]).
@@ -217,8 +227,7 @@ TToElementWithContextMenuTest >> testHasContextMenu [
 	self should: [ e newContextMenuOnEvent: nil ] raise: Error.
 	e contextMenuBuilder: [ :menu :request |
 		menu addAllItems: { ToMenuItem new } ].
-	self assert: e rawContextMenuManager notNil.
-	^ e
+	self assert: e rawContextMenuManager notNil
 ]
 
 { #category : #tests }
@@ -270,8 +279,8 @@ TToElementWithContextMenuTest >> testRawContextMenuManager [
 { #category : #tests }
 TToElementWithContextMenuTest >> testRemoveContextMenuBuilder [
 
-	|  e  |
-	e := self testContextMenu.
+	| e |
+	e := self newElementWithContextMenuBuilder.
 	self assert: e rawContextMenuManager notNil.
 	e removeContextMenuBuilder.
 	self assert: e rawContextMenuManager isNil

--- a/src/Toplo-Tests/TToElementWithPlaceholderTest.class.st
+++ b/src/Toplo-Tests/TToElementWithPlaceholderTest.class.st
@@ -60,12 +60,6 @@ TToElementWithPlaceholderTest >> testPlaceholderElevation [
 ]
 
 { #category : #tests }
-TToElementWithPlaceholderTest >> testPlaceholderLayer [
-
-	self testHidePlaceholder 
-]
-
-{ #category : #tests }
 TToElementWithPlaceholderTest >> testPlaceholderString [
 
 	| e ph |

--- a/src/Toplo-Tests/TToElementWithTooltipTest.class.st
+++ b/src/Toplo-Tests/TToElementWithTooltipTest.class.st
@@ -15,19 +15,25 @@ TToElementWithTooltipTest >> testCloseTooltipOnMouseLeave [
 	e extent: 50 @ 50.
 	e tooltipManagerDo: [ :m | m popupDelay: 10 milliSeconds ].
 	space deferAndSettle: [ space root addChild: e ].
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip window must be nil before opening'.
+
 	e tooltipBuilder: [ :win :request |
 			win root addChild: (ToElement new
 					 extent: 20 @ 20;
 					 yourself) ].
 	e eventSimulator mouseMoveInside.
 	space waitUntilTrue: [ e currentTooltipWindow notNil ].
-	self assert: e currentTooltipWindow notNil.
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip window must open on mouse move inside'.
+
 	e eventSimulator mouseMoveOutside.
 	space waitUntilTrue: [ e currentTooltipWindow isNil ].
-	self assert: e currentTooltipWindow isNil.
-
-	^ e
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip window must close on mouse move outside'
 ]
 
 { #category : #tests }
@@ -39,17 +45,25 @@ TToElementWithTooltipTest >> testCloseTooltipOnMouseLeave2 [
 	e tooltipManagerDo: [ :m | m closeOnLeaved: false ].
 	e tooltipManagerDo: [ :m | m popupDelay: 10 milliSeconds ].
 	space deferAndSettle: [ space root addChild: e ].
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip window must be nil before opening'.
+
 	e tooltipBuilder: [ :win :request |
 			win root addChild: (ToElement new
 					 extent: 20 @ 20;
 					 yourself) ].
 	e eventSimulator mouseMoveInside.
 	space waitUntilTrue: [ e currentTooltipWindow notNil ].
-	self assert: e currentTooltipWindow notNil.
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip window must open on mouse move inside'.
+
 	e eventSimulator mouseMoveOutside.
 	space waitForDuration: 50 milliSeconds.
-	self assert: e currentTooltipWindow notNil
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip window must remain open when closeOnLeaved is false'
 ]
 
 { #category : #tests }
@@ -58,14 +72,20 @@ TToElementWithTooltipTest >> testCurrentTooltipWindow [
 	| e |
 	e := ToElement new.
 	e tooltipBuilder: [ :win :request | win root addChild: ToElement new ].
-	self assert: e hasTooltip.
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after installing builder'.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip window must be nil before window creation'.
+
 	e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: e currentTooltipWindow notNil.
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip window must exist after creation'.
 	self
 		assert: e currentTooltipWindow class
-		equals: e ensuredTooltipManager windowClass.
-	^ e
+		equals: e ensuredTooltipManager windowClass
 ]
 
 { #category : #tests }
@@ -73,17 +93,28 @@ TToElementWithTooltipTest >> testEnsuredTooltipManager [
 
 	| e |
 	e := ToElement new.
-	self assert: e currentTooltipWindow isNil.
-	self assert: e rawTooltipManager isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'New element must have no current tooltip window'.
+	self
+		assert: e rawTooltipManager isNil
+		description: 'New element must have no raw tooltip manager'.
+
 	e tooltip: [ :win :theRequest | win root addChild: ToElement new ].
-	self assert: e hasTooltip.
-	self assert: e rawTooltipManager notNil.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after setting tooltip'.
+	self
+		assert: e rawTooltipManager notNil
+		description: 'Raw tooltip manager must exist after setting tooltip'.
+
 	e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: e ensuredTooltipManager currentWindow notNil.
+	self
+		assert: e ensuredTooltipManager currentWindow notNil
+		description: 'Current window must exist after creation'.
 	self
 		assert: e ensuredTooltipManager anchorElement
-		identicalTo: e.
-	^ e
+		identicalTo: e
 ]
 
 { #category : #tests }
@@ -92,13 +123,17 @@ TToElementWithTooltipTest >> testHasOpenedTooltip [
 	| e |
 	e := ToElement new.
 	e tooltipBuilder: [ :win :request | win root addChild: ToElement new ].
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip window must be nil before window creation'.
+
 	e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: e currentTooltipWindow notNil.
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip window must exist after window creation'.
 	self
 		assert: e currentTooltipWindow class
-		equals: e ensuredTooltipManager windowClass.
-	^ e
+		equals: e ensuredTooltipManager windowClass
 ]
 
 { #category : #tests }
@@ -106,13 +141,17 @@ TToElementWithTooltipTest >> testHasTooltip [
 
 	| e |
 	e := ToElement new.
-	self assert: e hasTooltip not.
+	self
+		assert: e hasTooltip not
+		description: 'New element must not have tooltip'.
 	self
 		should: [ e rawTooltipManager createNewWindowOnEvent: nil ]
 		raise: Error.
+
 	e tooltipBuilder: [ :win :request | win root addChild: ToElement new ].
-	self assert: e hasTooltip.
-	^ e
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after installing builder'
 ]
 
 { #category : #tests }
@@ -120,20 +159,31 @@ TToElementWithTooltipTest >> testNewTooltipOnEvent [
 
 	| e |
 	e := ToElement new.
-	self assert: e currentTooltipWindow isNil.
-	self assert: e rawTooltipManager isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'New element must have no current tooltip window'.
+	self
+		assert: e rawTooltipManager isNil
+		description: 'New element must have no raw tooltip manager'.
 	self
 		should: [ e rawTooltipManager createNewWindowOnEvent: nil ]
 		raise: Error.
+
 	e tooltipBuilder: [ :win :request | win root addChild: ToElement new ].
-	self assert: e hasTooltip.
-	self assert: e rawTooltipManager notNil.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after installing builder'.
+	self
+		assert: e rawTooltipManager notNil
+		description: 'Raw tooltip manager must exist after installing builder'.
+
 	e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: e ensuredTooltipManager currentWindow notNil.
+	self
+		assert: e ensuredTooltipManager currentWindow notNil
+		description: 'Current window must exist after creation'.
 	self
 		assert: e currentTooltipWindow
-		identicalTo: e ensuredTooltipManager currentWindow.
-	^ e
+		identicalTo: e ensuredTooltipManager currentWindow
 ]
 
 { #category : #tests }
@@ -141,23 +191,37 @@ TToElementWithTooltipTest >> testRawTooltipManager [
 
 	| e |
 	e := ToElement new.
-	self assert: e rawTooltipManager isNil.
+	self
+		assert: e rawTooltipManager isNil
+		description: 'New element must have no raw tooltip manager'.
+
 	e tooltipBuilder: [ :win :request | win root addChild: ToElement new ].
-	self assert: e rawTooltipManager notNil.
+	self
+		assert: e rawTooltipManager notNil
+		description: 'Raw tooltip manager must exist after installing builder'.
+
 	e removeTooltipManager.
-	self assert: e rawTooltipManager isNil
+	self
+		assert: e rawTooltipManager isNil
+		description: 'Raw tooltip manager must be nil after removal'
 ]
 
 { #category : #tests }
 TToElementWithTooltipTest >> testRemoveTooltip [
 
-	|  e  |
+	| e |
 	e := self testTooltip.
-	self assert: e hasTooltip.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip from testTooltip'.
+
 	e removeTooltip.
-	self assert: e currentTooltipWindow isNil.
-	self assert: e hasTooltip not.
-	^ e
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Current tooltip window must be nil after removing tooltip'.
+	self
+		assert: e hasTooltip not
+		description: 'Element must not have tooltip after removing tooltip'
 ]
 
 { #category : #tests }
@@ -165,11 +229,17 @@ TToElementWithTooltipTest >> testRemoveTooltipManager [
 
 	| e |
 	e := self testTooltip.
-	self assert: e hasTooltip.
-	self assert: (e userData includesKey: #tooltipManager).
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip from testTooltip'.
+	self
+		assert: (e userData includesKey: #tooltipManager)
+		description: 'User data must contain tooltipManager key'.
+
 	e removeTooltipManager.
-	self deny: (e userData includesKey: #tooltipManager).
-	^ e
+	self
+		deny: (e userData includesKey: #tooltipManager)
+		description: 'User data must not contain tooltipManager key after removal'
 ]
 
 { #category : #tests }
@@ -178,13 +248,25 @@ TToElementWithTooltipTest >> testTooltip [
 	| tt e ttwin |
 	tt := BlElement new.
 	e := ToElement new.
-	self assert: e hasTooltip not.
+	self
+		assert: e hasTooltip not
+		description: 'New element must not have tooltip'.
+
 	e tooltip: [ :win :theRequest | win root addChild: tt ].
-	self assert: e hasTooltip.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after configuration'.
+
 	ttwin := e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: e currentTooltipWindow identicalTo: ttwin.
-	self assert: ttwin root firstChild identicalTo: tt.
-	self assert: ttwin anchorElement identicalTo: e.
+	self
+		assert: e currentTooltipWindow
+		identicalTo: ttwin.
+	self
+		assert: ttwin root firstChild
+		identicalTo: tt.
+	self
+		assert: ttwin anchorElement
+		identicalTo: e.
 	^ e
 ]
 
@@ -195,10 +277,17 @@ TToElementWithTooltipTest >> testTooltipBuilder [
 	e := ToElement new.
 	b := [ :win :theRequest | win root addChild: ToElement new ].
 	e tooltipBuilder: b.
-	self assert: e rawTooltipManager notNil.
-	self assert: e rawTooltipManager windowBuilder identicalTo: b.
+	self
+		assert: e rawTooltipManager notNil
+		description: 'Raw tooltip manager must exist after setting builder'.
+	self
+		assert: e rawTooltipManager windowBuilder
+		identicalTo: b.
+
 	e removeTooltipManager.
-	self assert: e rawTooltipManager isNil
+	self
+		assert: e rawTooltipManager isNil
+		description: 'Raw tooltip manager must be nil after removal'
 ]
 
 { #category : #tests }
@@ -207,7 +296,8 @@ TToElementWithTooltipTest >> testTooltipPopupDelay [
 	| e |
 	e := ToElement new.
 	e extent: 50 @ 50.
-	"Use a 300ms threshold after which the tooltip opens"
+
+	"Set the delay threshold after which the tooltip opens"
 	e tooltipManagerDo: [ :m |
 		m popupDelay: 300 milliSeconds.
 		self assert: m popupDelay equals: 300 milliSeconds ].
@@ -221,25 +311,35 @@ TToElementWithTooltipTest >> testTooltipPopupDelay [
 
 	"Hovering starts the delay countdown; the tooltip must not appear immediately"
 	e eventSimulator mouseMoveInside.
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip must not open immediately upon mouse enter'.
 
 	"After a little wait, the tooltip must still not be opened"
 	space waitForDuration: 20 milliSeconds.
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip must remain closed before popupDelay elapses'.
 
-	"Once the 300ms popupDelay elapses, the tooltip window opens"
+	"Once the delay elapses, the tooltip window opens"
 	space waitUntilTrue: [ e currentTooltipWindow notNil ].
-	self assert: e currentTooltipWindow notNil.
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip must open after popupDelay elapses'.
 
 	"Moving the mouse outside closes the tooltip"
 	e eventSimulator mouseMoveOutside.
 	space waitUntilTrue: [ e currentTooltipWindow isNil ].
-	self assert: e currentTooltipWindow isNil.
+	self
+		assert: e currentTooltipWindow isNil
+		description: 'Tooltip must close upon mouse move outside'.
 
 	"Re-entering the element starts a new delay cycle and opens the tooltip again"
 	e eventSimulator mouseMoveInside.
 	space waitUntilTrue: [ e currentTooltipWindow notNil ].
-	self assert: e currentTooltipWindow notNil
+	self
+		assert: e currentTooltipWindow notNil
+		description: 'Tooltip must open again on re-entering element'
 ]
 
 { #category : #tests }
@@ -249,12 +349,22 @@ TToElementWithTooltipTest >> testTooltipRequestEvent [
 	| tt e ttwin request |
 	tt := BlElement new.
 	e := ToElement new.
-	self deny: e hasTooltip.
+	self
+		deny: e hasTooltip
+		description: 'New element must not have tooltip'.
+
 	e tooltip: [ :win :theRequest | win root addChild: tt. request := theRequest ].
-	self assert: e hasTooltip.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after configuration'.
+
 	ttwin := e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: request class identicalTo: ttwin manager windowRequestClass.
-	self assert: request target identicalTo: e
+	self
+		assert: request class
+		identicalTo: ttwin manager windowRequestClass.
+	self
+		assert: request target
+		identicalTo: e
 ]
 
 { #category : #tests }
@@ -263,13 +373,22 @@ TToElementWithTooltipTest >> testTooltipString [
 	| tt e ttwin |
 	tt := BlElement new.
 	e := ToElement new.
-	self assert: e hasTooltip not.
+	self
+		assert: e hasTooltip not
+		description: 'New element must not have tooltip'.
+
 	e tooltipString: 'X'.
-	self assert: e hasTooltip.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after setting tooltipString'.
+
 	ttwin := e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: ttwin root firstChild notNil.
-	self assert: ttwin root firstChild text asString equals: 'X'.
-	^ e
+	self
+		assert: ttwin root firstChild notNil
+		description: 'Tooltip window must contain a child'.
+	self
+		assert: ttwin root firstChild text asString
+		equals: 'X'
 ]
 
 { #category : #tests }
@@ -278,12 +397,23 @@ TToElementWithTooltipTest >> testTooltipText [
 	| tt e ttwin |
 	tt := BlElement new.
 	e := ToElement new.
-	self assert: e hasTooltip not.
-	e tooltipText: ('X' asRopedText).
-	self assert: e hasTooltip.
+	self
+		assert: e hasTooltip not
+		description: 'New element must not have tooltip'.
+
+	e tooltipText: 'X' asRopedText.
+	self
+		assert: e hasTooltip
+		description: 'Element must have tooltip after setting tooltipText'.
+
 	ttwin := e rawTooltipManager createNewWindowOnEvent: nil.
-	self assert: ttwin root firstChild notNil.
-	self assert: (ttwin root firstChild isKindOf: ToLabel).
-	self assert: ttwin root firstChild text asString equals: 'X' asRopedText asString.
-	^ e
+	self
+		assert: ttwin root firstChild notNil
+		description: 'Tooltip window must contain a child'.
+	self
+		assert: (ttwin root firstChild isKindOf: ToLabel)
+		description: 'Tooltip content child must be a ToLabel'.
+	self
+		assert: ttwin root firstChild text asString
+		equals: 'X' asRopedText asString
 ]

--- a/src/Toplo-Tests/TToElementWithTooltipTest.class.st
+++ b/src/Toplo-Tests/TToElementWithTooltipTest.class.st
@@ -7,6 +7,16 @@ Class {
 	#category : #'Toplo-Tests-Core'
 }
 
+{ #category : #helpers }
+TToElementWithTooltipTest >> newElementWithTooltip [
+
+	| e |
+	e := ToElement new.
+	e tooltip: [ :win :theRequest | win root addChild: BlElement new ].
+	e rawTooltipManager createNewWindowOnEvent: nil.
+	^ e
+]
+
 { #category : #tests }
 TToElementWithTooltipTest >> testCloseTooltipOnMouseLeave [
 
@@ -210,10 +220,10 @@ TToElementWithTooltipTest >> testRawTooltipManager [
 TToElementWithTooltipTest >> testRemoveTooltip [
 
 	| e |
-	e := self testTooltip.
+	e := self newElementWithTooltip.
 	self
 		assert: e hasTooltip
-		description: 'Element must have tooltip from testTooltip'.
+		description: 'Element must have tooltip'.
 
 	e removeTooltip.
 	self
@@ -228,10 +238,10 @@ TToElementWithTooltipTest >> testRemoveTooltip [
 TToElementWithTooltipTest >> testRemoveTooltipManager [
 
 	| e |
-	e := self testTooltip.
+	e := self newElementWithTooltip.
 	self
 		assert: e hasTooltip
-		description: 'Element must have tooltip from testTooltip'.
+		description: 'Element must have tooltip'.
 	self
 		assert: (e userData includesKey: #tooltipManager)
 		description: 'User data must contain tooltipManager key'.
@@ -266,8 +276,7 @@ TToElementWithTooltipTest >> testTooltip [
 		identicalTo: tt.
 	self
 		assert: ttwin anchorElement
-		identicalTo: e.
-	^ e
+		identicalTo: e
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/ToLabeledIconTest.class.st
+++ b/src/Toplo-Tests/ToLabeledIconTest.class.st
@@ -7,6 +7,26 @@ Class {
 	#category : #'Toplo-Tests-Core'
 }
 
+{ #category : #helpers }
+ToLabeledIconTest >> newLabeledIcon [
+
+	^ ToLabeledIcon new
+]
+
+{ #category : #helpers }
+ToLabeledIconTest >> newLabeledIconWithIcon [
+
+	| li |
+	li := self newLabeledIcon.
+	li icon:
+		(ToImage inner:
+			(BlElement new
+				extent: 60 @ 20;
+				background: (Color blue alpha: 0.2);
+				yourself)).
+	^ li
+]
+
 { #category : #running }
 ToLabeledIconTest >> setUp [ 
 
@@ -18,7 +38,8 @@ ToLabeledIconTest >> setUp [
 ToLabeledIconTest >> testBeIconFirst [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li iconImage:
@@ -35,7 +56,8 @@ ToLabeledIconTest >> testBeIconFirst [
 ToLabeledIconTest >> testBeLabelFirst [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li iconImage:
@@ -52,7 +74,8 @@ ToLabeledIconTest >> testBeLabelFirst [
 ToLabeledIconTest >> testFiller [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self assert: li startFiller isNil.
 
@@ -67,7 +90,8 @@ ToLabeledIconTest >> testFiller [
 ToLabeledIconTest >> testHasIcon [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self deny: li hasIcon.
 
@@ -86,7 +110,8 @@ ToLabeledIconTest >> testHasIcon [
 ToLabeledIconTest >> testHasLabel [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self deny: li hasLabel.
 
@@ -99,7 +124,8 @@ ToLabeledIconTest >> testHasLabel [
 ToLabeledIconTest >> testIcon [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li icon:
@@ -121,7 +147,8 @@ ToLabeledIconTest >> testIcon [
 ToLabeledIconTest >> testIconContainer [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self assert: li iconContainer isNil.
 
@@ -141,7 +168,8 @@ ToLabeledIconTest >> testIconContainer [
 ToLabeledIconTest >> testIconContainerHeight [
 
 	| li |
-	li := self testWithLabelAndIcon.
+	li := self newLabeledIconWithIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li iconContainer height: 40 ].
 	self
@@ -153,7 +181,8 @@ ToLabeledIconTest >> testIconContainerHeight [
 ToLabeledIconTest >> testIconContainerHeightVertical [
 
 	| li |
-	li := self testWithLabelAndIcon.
+	li := self newLabeledIconWithIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li beVertical.
@@ -170,7 +199,8 @@ ToLabeledIconTest >> testIconContainerHeightVertical [
 ToLabeledIconTest >> testIconContainerWidth [
 
 	| li |
-	li := self testWithLabelAndIcon.
+	li := self newLabeledIconWithIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li iconContainer width: 40 ].
 	self
@@ -185,8 +215,9 @@ ToLabeledIconTest >> testIconContainerWidth [
 ToLabeledIconTest >> testIconContainerWidthVertical [
 
 	| li |
-	li := self testWithLabelAndIcon.
-	
+	li := self newLabeledIconWithIcon.
+	space deferAndSettle: [ space root addChild: li ].
+
 	space deferAndSettle: [
 		li beVertical.
 		li iconContainer width: 40 ].
@@ -202,7 +233,8 @@ ToLabeledIconTest >> testIconContainerWidthVertical [
 ToLabeledIconTest >> testIconImage [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li iconImage:
@@ -218,12 +250,11 @@ ToLabeledIconTest >> testIconImage [
 ToLabeledIconTest >> testInitialize [
 
 	| li |
-	li := ToLabeledIcon new.
+	li := self newLabeledIcon.
 	space deferAndSettle: [ space root addChild: li ].
 	self assert: li isStartToEnd.
 	self assert: li isHorizontal.
-	self assert: li extent equals: 0 asPoint.
-	^ li
+	self assert: li extent equals: 0 asPoint
 ]
 
 { #category : #tests }
@@ -284,7 +315,8 @@ ToLabeledIconTest >> testInterspaceWithLabelAndVertical [
 ToLabeledIconTest >> testIsExact [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 	space deferAndSettle: [ li extent: 10 @ 10 ].
 	self assert: li isExact.
 
@@ -296,7 +328,8 @@ ToLabeledIconTest >> testIsExact [
 ToLabeledIconTest >> testIsIconFirst [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li beStartToEnd ].
 	self assert: li isStartToEnd.
@@ -308,7 +341,8 @@ ToLabeledIconTest >> testIsIconFirst [
 ToLabeledIconTest >> testIsLabelFirst [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li beEndToStart ].
 	self assert: li isEndToStart.
@@ -321,7 +355,8 @@ ToLabeledIconTest >> testIsLabelFirst [
 ToLabeledIconTest >> testIsStartFlexible [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self deny: li isStartFlexible.
 
@@ -333,7 +368,8 @@ ToLabeledIconTest >> testIsStartFlexible [
 ToLabeledIconTest >> testLabel [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li label: (ToLabel text: 'A') ].
 	self assert: li extent equals: li labelContainer extent.
@@ -341,16 +377,15 @@ ToLabeledIconTest >> testLabel [
 
 	space deferAndSettle: [ li label: nil ].
 	self assert: li label isNil.
-	self deny: li hasLabel.
-
-	^ li
+	self deny: li hasLabel
 ]
 
 { #category : #tests }
 ToLabeledIconTest >> testLabelContainer [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self assert: li labelContainer hasChildren not.
 	self assert: li labelContainer extent equals: 0 asPoint.
@@ -363,7 +398,8 @@ ToLabeledIconTest >> testLabelContainer [
 ToLabeledIconTest >> testLabelFirst [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li iconImage:
@@ -382,7 +418,8 @@ ToLabeledIconTest >> testLabelFirst [
 ToLabeledIconTest >> testLabelText [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [ li labelText: 'A' asRopedText ].
 	self assert: li label text asString equals: 'A'.
@@ -403,7 +440,8 @@ ToLabeledIconTest >> testLabelText [
 ToLabeledIconTest >> testStartAlignment [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li icon:
@@ -430,7 +468,8 @@ ToLabeledIconTest >> testStartAlignment [
 ToLabeledIconTest >> testStartFlexible [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	self assert: li startFiller isNil.
 
@@ -509,7 +548,8 @@ ToLabeledIconTest >> testStartFlexibleWithLabelAndVertical [
 ToLabeledIconTest >> testStartToEnd [
 
 	| li |
-	li := self testInitialize.
+	li := self newLabeledIcon.
+	space deferAndSettle: [ space root addChild: li ].
 
 	space deferAndSettle: [
 		li iconImage:
@@ -528,22 +568,14 @@ ToLabeledIconTest >> testStartToEnd [
 ToLabeledIconTest >> testWithLabelAndIcon [
 
 	| li |
-	li := self testLabel.
-
-	space deferAndSettle: [
-		li icon:
-			(ToImage inner:
-				(BlElement new
-					extent: 60 @ 20;
-					background: (Color blue alpha: 0.2);
-					yourself)) ].
+	li := self newLabeledIconWithIcon.
+	space deferAndSettle: [ space root addChild: li ].
 	self
 		assert: li width
 		equals: li labelContainer width + li iconContainer width.
 	self
 		assert: li height
-		equals: (li labelContainer height max: li iconContainer height).
-	^ li
+		equals: (li labelContainer height max: li iconContainer height)
 ]
 
 { #category : #tests }

--- a/src/Toplo-Tests/ToPopupWindowTest.class.st
+++ b/src/Toplo-Tests/ToPopupWindowTest.class.st
@@ -25,19 +25,27 @@ ToPopupWindowTest >> testElement [
 	win popup.
 	space settle.
 	self assert: win anchorElement equals: e.
-	self assert: win isOpened.
+	self
+		assert: win isOpened
+		description: 'Window must be opened after popup'.
 	win close.
 	space settle.
-	self assert: win isClosed.
+	self
+		assert: win isClosed
+		description: 'Window must be closed after close'.
 
 	win := windowManager createNewWindowOnEvent: nil.
 	win popup.
 	space settle.
 	self assert: win anchorElement equals: e.
-	self assert: win isOpened.
+	self
+		assert: win isOpened
+		description: 'Window must be opened on second popup'.
 	win close.
 	space settle.
-	self assert: win isClosed
+	self
+		assert: win isClosed
+		description: 'Window must be closed on second close'
 ]
 
 { #category : #tests }
@@ -57,21 +65,30 @@ ToPopupWindowTest >> testElementWithLabelEditorAndPopupWindowManager [
 	e addEventHandler: windowManager.
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
-
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup window must be created on mouse down'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup window must be open on mouse down'.
 
 	e popupEditorEvent: nil.
 
 	space waitUntilTrue: [ e editorWindowManager notNil ].
-	self assert: e editorWindowManager notNil.
-	self assert: e editorWindowManager editor notNil.
+	self
+		assert: e editorWindowManager notNil
+		description: 'Editor window manager must be created'.
+	self
+		assert: e editorWindowManager editor notNil
+		description: 'Editor element must be present in editor window'.
 	self
 		assert: e editorWindowManager editor text asString
 		equals: e text asString.
 	e editorWindowManager currentWindow close.
 	space waitUntilTrue: [ e editorWindowManager currentWindow isNil ].
-	self assert: e editorWindowManager editor isNil
+	self
+		assert: e editorWindowManager editor isNil
+		description: 'Editor must be cleared after editor window closes'
 ]
 
 { #category : #tests }
@@ -87,29 +104,43 @@ ToPopupWindowTest >> testElementWithTooltipAndPopupWindowManager [
 
 	windowManager := ToPopupWindowManager new.
 	windowManager windowBuilder: [ :anchWin :element |  ].
+	"Use a generous delay to give a safe margin against CI thread scheduling lag"
+	windowManager autoCloseDelay: 500 milliSeconds.
 	e addEventHandler: windowManager.
 	e tooltipBuilder: [ :win :request |
 		win root addChild: (ToLabel text: 'Tooltip content') ].
 	tooltipWindowManager := e ensuredTooltipManager.
-	self assert: tooltipWindowManager notNil.
+	self
+		assert: tooltipWindowManager notNil
+		description: 'Tooltip manager must be installed'.
 
 	" mouse down immediately followed by a mouse up -> the popup should stay opened"
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
-	self assert: windowManager currentWindow isOpened.
-	self assert: tooltipWindowManager currentWindow isNil.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must open on mouse down'.
+	self
+		assert: tooltipWindowManager currentWindow isNil
+		description: 'Tooltip must remain closed while popup is open'.
+
 	e eventSimulator mouseUp.
-	space waitForDuration: 400 milliSeconds.
-	self assert: windowManager currentWindow isOpened.
-	space waitForDuration: 150 milliSeconds.
+	space waitForDuration: 600 milliSeconds.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must stay open after a quick click'.
 
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
-	self assert: windowManager currentWindow isOpened.
-	e eventSimulator mouseUp.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must still be open on second mouse down'.
 
+	e eventSimulator mouseUp.
 	space waitUntilTrue: [ windowManager currentWindow isNil ].
-	self assert: windowManager currentWindow isNil
+	self
+		assert: windowManager currentWindow isNil
+		description: 'Popup must close on second click release'
 ]
 
 { #category : #tests }
@@ -131,29 +162,50 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseDownDelayUp [
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	e eventSimulator mouseUp.
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must exist after immediate click'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must stay open on immediate click'.
 
-	windowManager autoCloseDelay: 200 milliSeconds.
+	"Use a generous delay to give a safe margin against CI thread scheduling lag"
+	windowManager autoCloseDelay: 500 milliSeconds.
 
 	" mouse down then waiting for a delay < autoclose delay then a mouse up -> the popup should stay opened"
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must be created on second mouse down'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must be open on second mouse down'.
+
 	space waitForDuration: 50 milliSeconds.
 	e eventSimulator mouseUp.
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
-	
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must remain open when released before autoCloseDelay'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must still be opened after short-hold release'.
+
 	" mouse down then waiting for a delay > autoclose delay then a mouse up -> the popup should be closed"
 	e eventSimulator mouseDown.
-	space waitForDuration: 300 milliSeconds.
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	space waitForDuration: 600 milliSeconds.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must still exist during long hold'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must remain open during long hold'.
+
 	e eventSimulator mouseUp.
 	space waitUntilTrue: [ windowManager currentWindow isNil ].
-	self assert: windowManager currentWindow isNil
+	self
+		assert: windowManager currentWindow isNil
+		description: 'Popup must close on release after autoCloseDelay'
 ]
 
 { #category : #tests }
@@ -177,18 +229,25 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseDownOutside [
 			 on: ToClosedEvent
 			 do: [ :event | closed := true ]).
 			
-	windowManager autoCloseDelay: 200 milliSeconds.
+	"Use a generous delay to give a safe margin against CI thread scheduling lag"
+	windowManager autoCloseDelay: 500 milliSeconds.
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	e eventSimulator mouseUp.
-	self assert: windowManager currentWindow notNil.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must open on click'.
 
 	space root eventSimulator mouseDown.
-	space waitForDuration: 400 milliSeconds.
+	space waitForDuration: 600 milliSeconds.
 	space root eventSimulator mouseUp.
 	space waitUntilTrue: [ windowManager currentWindow isNil ].
-	self assert: closed.
-	self assert: windowManager currentWindow isNil
+	self
+		assert: closed
+		description: 'ToClosedEvent must be received on outside click'.
+	self
+		assert: windowManager currentWindow isNil
+		description: 'Popup must be nil after outside click'
 ]
 
 { #category : #tests }
@@ -213,26 +272,39 @@ ToPopupWindowTest >> testPopupOpenCloseWithMouseUpOutsideOnASibling [
 	windowManager windowBuilder: [ :anchWin :element |
 		anchWin addChild: (ToElement new extent: 100 @ 100) ].
 	e addEventHandler: windowManager.
-	windowManager autoCloseDelay: 100 milliSeconds.
+	"Use a generous delay to give a safe margin against CI thread scheduling lag"
+	windowManager autoCloseDelay: 500 milliSeconds.
 	" mouse down on widget then up on popup"
 	e eventSimulator mouseDown.
 	space waitUntilTrue: [ windowManager currentWindow notNil ].
 	e eventSimulator mouseUp.
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must exist after opening click'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must be opened after opening click'.
 
 	windowManager currentWindow eventSimulator mouseDown.
 	windowManager currentWindow eventSimulator mouseUp.
-	space waitForDuration: 400 milliSeconds.
-	self assert: windowManager currentWindow notNil.
-	self assert: windowManager currentWindow isOpened.
+	space waitForDuration: 600 milliSeconds.
+	self
+		assert: windowManager currentWindow notNil
+		description: 'Popup must remain open after click inside the popup itself'.
+	self
+		assert: windowManager currentWindow isOpened
+		description: 'Popup must still be opened after click inside the popup'.
 
 	closed := false.
 	e addEventHandlerOn: ToClosedEvent do: [ :event | closed := true ].
 	other eventSimulator mouseDown.
-	space waitForDuration: 400 milliSeconds.
+	space waitForDuration: 600 milliSeconds.
 	other eventSimulator mouseUp.
 	space waitUntilTrue: [ windowManager currentWindow isNil ].
-	self assert: closed.
-	self assert: windowManager currentWindow isNil
+	self
+		assert: closed
+		description: 'ToClosedEvent must be received on clicking outside sibling'.
+	self
+		assert: windowManager currentWindow isNil
+		description: 'Popup must close on clicking outside sibling'
 ]

--- a/src/Toplo-Tests/ToShrinkableContainerTest.class.st
+++ b/src/Toplo-Tests/ToShrinkableContainerTest.class.st
@@ -17,28 +17,26 @@ ToShrinkableContainerTest >> testContainerSizeChange [
 	space deferAndSettle: [ e extent: 20 asPoint ].
 	self
 		assert: e shrinkFeedbackLayer visibility
-		equals: BlVisibility visible.
-	^ e
+		equals: BlVisibility visible
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testEnableShrinkLayer [
 
-	| e  |
+	| e |
 	e := ToShrinkableContainer new.
 	space deferAndSettle: [
 		space root addChild: e.
 		e enableShrinkLayer: true ].
 	self assert: e shrinkFeedbackLayer notNil.
 	self assert: (e shrinkFeedbackLayer isKindOf: ToShrinkFeedbackLayer).
-	self assert: e shrinkFeedbackLayer visibility equals: BlVisibility hidden.
-	^ e
+	self assert: e shrinkFeedbackLayer visibility equals: BlVisibility hidden
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testEnableShrinkLayer2 [
 
-	| e  |
+	| e |
 	e := ToShrinkableContainer new.
 	space deferAndSettle: [
 		space root addChild: e.
@@ -46,8 +44,7 @@ ToShrinkableContainerTest >> testEnableShrinkLayer2 [
 	self assert: e shrinkFeedbackLayer notNil.
 
 	space deferAndSettle: [ e enableShrinkLayer: false ].
-	self assert: e shrinkFeedbackLayer isNil.
-	^ e
+	self assert: e shrinkFeedbackLayer isNil
 ]
 
 { #category : #tests }
@@ -71,14 +68,13 @@ ToShrinkableContainerTest >> testIsShrinked [
 	self deny: e isShrinked.
 
 	space deferAndSettle: [ child extent: 150 asPoint ].
-	self assert: e isShrinked.
-	^ e
+	self assert: e isShrinked
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testIsShrinkedHorizontally [
 
-	| e  child |
+	| e child |
 	e := ToShrinkableContainer new.
 	" horizontal is the default "
 	e checkHorizontalShrinkability.
@@ -96,14 +92,13 @@ ToShrinkableContainerTest >> testIsShrinkedHorizontally [
 	self assert: e isShrinked.
 
 	space deferAndSettle: [ e width: 200 ].
-	self deny: e isShrinked.
-	^ e
+	self deny: e isShrinked
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testIsShrinkedHorizontally2 [
 
-	| e  child |
+	| e child |
 	e := ToShrinkableContainer new.
 	" horizontal is the default "
 	e checkHorizontalShrinkability.
@@ -121,14 +116,13 @@ ToShrinkableContainerTest >> testIsShrinkedHorizontally2 [
 	self deny: e isShrinked.
 
 	space deferAndSettle: [ e height: 200 ].
-	self deny: e isShrinked.
-	^ e
+	self deny: e isShrinked
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testIsShrinkedVertically [
 
-	| e  child |
+	| e child |
 	e := ToShrinkableContainer new.
 	" horizontal is the default "
 	e checkVerticalShrinkability.
@@ -146,14 +140,13 @@ ToShrinkableContainerTest >> testIsShrinkedVertically [
 	self assert: e isShrinked.
 
 	space deferAndSettle: [ e height: 200 ].
-	self deny: e isShrinked.
-	^ e
+	self deny: e isShrinked
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testIsShrinkedVertically2 [
 
-	| e  child |
+	| e child |
 	e := ToShrinkableContainer new.
 	" horizontal is the default "
 	e checkVerticalShrinkability.
@@ -171,8 +164,7 @@ ToShrinkableContainerTest >> testIsShrinkedVertically2 [
 	self deny: e isShrinked.
 
 	space deferAndSettle: [ e width: 200 ].
-	self deny: e isShrinked.
-	^ e
+	self deny: e isShrinked
 ]
 
 { #category : #tests }
@@ -208,6 +200,5 @@ ToShrinkableContainerTest >> testShrinkableContainerVisible [
 	space deferAndSettle: [ child extent: 150 asPoint ].
 	self
 		assert: e shrinkFeedbackLayer visibility
-		equals: BlVisibility visible.
-	^ e
+		equals: BlVisibility visible
 ]

--- a/src/Toplo-Tests/ToShrinkableContainerTest.class.st
+++ b/src/Toplo-Tests/ToShrinkableContainerTest.class.st
@@ -7,11 +7,30 @@ Class {
 	#category : #'Toplo-Tests-Core-Overlay'
 }
 
+{ #category : #helpers }
+ToShrinkableContainerTest >> newShrinkableContainerWithChild [
+
+	| e child |
+	e := ToShrinkableContainer new.
+	e enableShrinkLayer: true.
+	e extent: 100 asPoint.
+	e border: Color red.
+	child := ToElement new.
+	child id: #child.
+	" make the child size less than the container size
+	this let the shrink layer invisible"
+	child extent: 50 asPoint.
+	e addChild: child.
+	^ e
+]
+
 { #category : #tests }
 ToShrinkableContainerTest >> testContainerSizeChange [
 
 	| e |
-	e := self testShrinkableContainerNotVisible.
+	e := self newShrinkableContainerWithChild.
+	space deferAndSettle: [ space root addChild: e ].
+
 	" make the container size smaller than the child size
 	this makes the shrink layer visible"
 	space deferAndSettle: [ e extent: 20 asPoint ].
@@ -170,31 +189,23 @@ ToShrinkableContainerTest >> testIsShrinkedVertically2 [
 { #category : #tests }
 ToShrinkableContainerTest >> testShrinkableContainerNotVisible [
 
-	| e child |
-	e := ToShrinkableContainer new.
-	e enableShrinkLayer: true.
-	e extent: 100 asPoint.
-	e border: Color red.
-	child := ToElement new.
-	child id: #child.
-	" make the child size less than the container size
-	this let the shrink layer invisible"
-	child extent: 50 asPoint.
-	e addChild: child.
+	| e |
+	e := self newShrinkableContainerWithChild.
 	space deferAndSettle: [ space root addChild: e ].
 	self assert: e shrinkFeedbackLayer parent equals: e.
 	self
 		assert: e shrinkFeedbackLayer visibility
-		equals: BlVisibility hidden.
-	^ e
+		equals: BlVisibility hidden
 ]
 
 { #category : #tests }
 ToShrinkableContainerTest >> testShrinkableContainerVisible [
 
 	| e child |
-	e := self testShrinkableContainerNotVisible.
+	e := self newShrinkableContainerWithChild.
+	space deferAndSettle: [ space root addChild: e ].
 	child := e childWithId: #child.
+
 	" make the child size greater than the container size
 	this makes the shrink layer visible"
 	space deferAndSettle: [ child extent: 150 asPoint ].

--- a/src/Toplo-Tests/ToTooltipWindowTest.class.st
+++ b/src/Toplo-Tests/ToTooltipWindowTest.class.st
@@ -47,8 +47,12 @@ ToTooltipWindowTest >> testCurrentWindow [
 
 	| tooltipWindow |
 	tooltipWindow := self setUpTooltipWindow.
-	self assert: tooltipWindow notNil.
-	self assert: tooltipWindow isOpened
+	self
+		assert: tooltipWindow notNil
+		description: 'Tooltip window must be created'.
+	self
+		assert: tooltipWindow isOpened
+		description: 'Tooltip window must be opened'
 ]
 
 { #category : #tests }
@@ -64,5 +68,7 @@ ToTooltipWindowTest >> testDefaultElevation [
 { #category : #tests }
 ToTooltipWindowTest >> testInitialize [
 
-	self deny: ToTooltipWindow new hasManager
+	self
+		deny: ToTooltipWindow new hasManager
+		description: 'New tooltip window must not have a manager'
 ]


### PR DESCRIPTION
- Reinforced a couple of tests that include hardcoded delays, and add some comments since they are not simple to comprehend
- Add some descriptions to asserts, to help understanding their meaning when reading the code but also to improve the CI log in the case of failure
- Delete trailing return statements in tests that have no senders